### PR TITLE
Fix sum rnode tree to render properly

### DIFF
--- a/app/src/main/java/io/github/karino2/kotlitex/MathExpressionSpan.kt
+++ b/app/src/main/java/io/github/karino2/kotlitex/MathExpressionSpan.kt
@@ -10,7 +10,7 @@ import io.github.karino2.kotlitex.renderer.node.*
 private class MathExpressionDrawable(expr: String, baseSize: Float, val drawBounds: Boolean = false) : Drawable() {
     var rootNode: VerticalList
     init {
-        val options = Options(Style.TEXT)
+        val options = Options(Style.DISPLAY)
         val parser = Parser(expr)
         val parsed =  parser.parse()
         val nodes = RenderTreeBuilder.buildExpression(parsed, options, true)
@@ -37,13 +37,13 @@ private class MathExpressionDrawable(expr: String, baseSize: Float, val drawBoun
     }
 
     // TODO
-    override fun getIntrinsicWidth(): Int = 200
-    override fun getIntrinsicHeight(): Int = 200
+    override fun getIntrinsicWidth(): Int = 400
+    override fun getIntrinsicHeight(): Int = 400
     private fun translateX(x: Double): Float {
         return x.toFloat() + 100
     }
     private fun translateY(y: Double): Float {
-        return y.toFloat() + 100
+        return y.toFloat() + 200
     }
 
     private fun drawBounds(canvas: Canvas, bounds: Bounds) {

--- a/app/src/main/java/io/github/karino2/kotlitex/Parser.kt
+++ b/app/src/main/java/io/github/karino2/kotlitex/Parser.kt
@@ -62,7 +62,6 @@ data class Settings(val displayMode :Boolean = false, val throwOnError: Boolean 
                     val maxSize: Int = Int.MAX_VALUE,
                     val maxExpand: Int = 1000,
                     val allowedProtocols: List<String> = emptyList()) {
-
     /**
      * Report nonstrict (non-LaTeX-compatible) input.
      * Can safely not be called if `this.strict` is false in JavaScript.
@@ -104,7 +103,7 @@ data class AccentRelation(val text: String, val math: String) {
     fun get(mode: Mode) =if(mode==Mode.MATH) math else text
 }
 
-class Parser(val input: String) {
+class Parser(val input: String, val settings:Settings = Settings()) {
     companion object {
         val endOfExpression = listOf("}", "\\end", "\\right", "&");
         val SUPSUB_GREEDINESS = 1
@@ -118,7 +117,7 @@ class Parser(val input: String) {
     }
 
 
-    val settings = Settings()
+
 
 
     var mode = Mode.MATH

--- a/app/src/test/java/io/github/karino2/kotlitex/RenderTreeBuilderTest.kt
+++ b/app/src/test/java/io/github/karino2/kotlitex/RenderTreeBuilderTest.kt
@@ -53,8 +53,8 @@ fun assertSpan(node: RenderNode?, body: SpanAsserter.()->Unit) {
 
 
 class RenderTreeBuilderTest {
-    fun parse(input: String) : List<ParseNode> {
-        val parser = Parser(input)
+    fun parse(input: String, settings: Settings = Settings()) : List<ParseNode> {
+        val parser = Parser(input, settings)
         return  parser.parse()
     }
 
@@ -284,8 +284,9 @@ class RenderTreeBuilderTest {
 
     @Test
     fun buildExpression_sum() {
+        val opt = Options(Style.DISPLAY)
         val input = parse("\\sum^N_{k=1} k")
-        val actual = RenderTreeBuilder.buildExpression(input, options, true)
+        val actual = RenderTreeBuilder.buildExpression(input, opt, true)
 
         assertTrue(actual.isNotEmpty())
     }

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.3.0'
+        classpath 'com.android.tools.build:gradle:3.3.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/sample/src/main/java/io/github/karino2/kotlitex/sample/MainActivity.kt
+++ b/sample/src/main/java/io/github/karino2/kotlitex/sample/MainActivity.kt
@@ -15,11 +15,12 @@ class MainActivity : AppCompatActivity() {
         setContentView(R.layout.activity_main)
 
         val textView = findViewById<TextView>(R.id.textView)
-        val spannable = SpannableStringBuilder("01234567 and the remaining text.")
+        val spannable = SpannableStringBuilder("01234567 91 345 789 234 678 and the remaining text.")
         spannable.setSpan(MathExpressionSpan("x^2", BIGGER_SIZE_FOR_DEBUGGING), 0, 2, Spannable.SPAN_INCLUSIVE_EXCLUSIVE)
         spannable.setSpan(MathExpressionSpan("\\frac{1}{2}", BIGGER_SIZE_FOR_DEBUGGING), 2, 4, Spannable.SPAN_INCLUSIVE_EXCLUSIVE)
         spannable.setSpan(MathExpressionSpan("\\sqrt{3}", BIGGER_SIZE_FOR_DEBUGGING), 4, 6, Spannable.SPAN_INCLUSIVE_EXCLUSIVE)
         spannable.setSpan(MathExpressionSpan("\\frac{1}{1+\\frac{1}{x^2}}", BIGGER_SIZE_FOR_DEBUGGING), 6, 8, Spannable.SPAN_INCLUSIVE_EXCLUSIVE)
+        spannable.setSpan(MathExpressionSpan("\\sum^N_{k=1} k", BIGGER_SIZE_FOR_DEBUGGING), 22, 25, Spannable.SPAN_INCLUSIVE_EXCLUSIVE)
         textView.text = spannable
     }
 }


### PR DESCRIPTION
The reason that sum did not handle sup-sub specially is because RNode is wrong.
So this PR is not rendering fix, but fixes #53 .

Also,  canvas-latex use mode DISPLAY, so I change our default to DISPLAY.
It makes font size larger and current hard-coded size is too small.
So I also adjust hard-coded size.