### PR TITLE
Sqrt top value fix

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -35,7 +35,7 @@
       </value>
     </option>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" project-jdk-name="1.8" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_7" project-jdk-name="1.8" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -19,6 +19,17 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
+
+    sourceSets {
+        String testCommon = "src/testCommon/java"
+        test {
+            java.srcDir testCommon
+        }
+        androidTest {
+            java.srcDir testCommon
+        }
+    }
+
 }
 
 dependencies {

--- a/app/src/androidTest/java/io/github/karino2/kotlitex/RenderTreeBuilderInstrumentedTest.kt
+++ b/app/src/androidTest/java/io/github/karino2/kotlitex/RenderTreeBuilderInstrumentedTest.kt
@@ -37,4 +37,25 @@ class RenderTreeBuilderInstrumentedTest {
         assertTrue(actual.isNotEmpty())
     }
 
+    @Test
+    fun buildExpression_sqrt() {
+        val opt = Options(Style.DISPLAY)
+        val input = parse("\\sqrt{3}")
+        val actual = RenderTreeBuilder.buildExpression(input, opt, true)
+
+        assertEquals(1, actual.size)
+        val target = actual[0]
+
+        assertSpan(target) { ac(0) { ac(0){ ac(0){ac(1)
+        {
+            // what canvas-latex obtain.
+            // styleTop("-2.916095em")
+
+            styleTop("-3.62519em")
+        }
+        }}}}
+    }
+
+
+
 }

--- a/app/src/androidTest/java/io/github/karino2/kotlitex/RenderTreeBuilderInstrumentedTest.kt
+++ b/app/src/androidTest/java/io/github/karino2/kotlitex/RenderTreeBuilderInstrumentedTest.kt
@@ -48,10 +48,7 @@ class RenderTreeBuilderInstrumentedTest {
 
         assertSpan(target) { ac(0) { ac(0){ ac(0){ac(1)
         {
-            // what canvas-latex obtain.
-            // styleTop("-2.916095em")
-
-            styleTop("-3.62519em")
+            styleTop("-2.916095em")
         }
         }}}}
     }

--- a/app/src/main/java/io/github/karino2/kotlitex/RenderBuilderDelimiter.kt
+++ b/app/src/main/java/io/github/karino2/kotlitex/RenderBuilderDelimiter.kt
@@ -593,7 +593,7 @@ object RenderBuilderDelimiter {
     /**
      * Make a sqrt image of the given height,
      */
-    fun makeSqrtImage(height: Double, options: Options) : Triple<RNodePathSpan, /*ruleWidth*/ Double, /*advancedWidth*/ Double> {
+    fun makeSqrtImage(height: Double, options: Options) : Triple<RNodePathSpan, /*advancedWidth*/ Double, /*ruleWidth*/ Double> {
         // Define a newOptions that removes the effect of size changes such as \Huge.
         // We don't pick different a height surd for \Huge. For it, we scale up.
         val newOptions = options.havingBaseSizing()

--- a/app/src/main/java/io/github/karino2/kotlitex/functions/FunctionSqrt.kt
+++ b/app/src/main/java/io/github/karino2/kotlitex/functions/FunctionSqrt.kt
@@ -45,7 +45,7 @@ object FunctionSqrt {
         val minDelimiterHeight = inner.height + inner.depth + lineClearance + theta // Create a sqrt SVG of the required minimum size
 
         // Create a sqrt SVG of the required minimum size
-        val (img, ruleWidth, advanceWidth) =
+        val (img, advanceWidth, ruleWidth) =
                 makeSqrtImage(minDelimiterHeight, options);
 
         val delimDepth = img.height - ruleWidth;

--- a/app/src/test/java/io/github/karino2/kotlitex/RenderTreeBuilderTest.kt
+++ b/app/src/test/java/io/github/karino2/kotlitex/RenderTreeBuilderTest.kt
@@ -1,55 +1,7 @@
 package io.github.karino2.kotlitex
 
 import org.junit.Test
-
 import org.junit.Assert.*
-
-class SymbolAsserter(val node: RNodeSymbol) {
-    fun text(v: String) = assertEquals(v, node.text)
-    fun h(v: Double) = assertEquals(v, node.height, 0.0001)
-    fun depth(v: Double) = assertEquals(v, node.depth, 0.001)
-    fun skew(v: Double) = assertEquals(v, node.skew, 0.0001)
-    fun w(v: Double) = assertEquals(v, node.width, 0.00001)
-    fun maxFont(v: Double) = assertEquals(v, node.maxFontSize, 0.01)
-    fun knum(numOfClass: Int) = assertEquals(numOfClass, node.klasses.size)
-    fun kl(klass: CssClass) = assertTrue(node.klasses.contains(klass))
-}
-
-fun assertSymbol(node: RenderNode?, body: SymbolAsserter.()->Unit) {
-    assertTrue(node is RNodeSymbol)
-    val sym: RNodeSymbol = node as RNodeSymbol
-    SymbolAsserter(sym).body()
-}
-
-class SpanAsserter(val node: RNodeSpan) {
-    fun cnum(numOfChildren: Int) = assertEquals(numOfChildren, node.children.size)
-    fun h(v: Double) = assertEquals(v, node.height, 0.0001)
-    fun depth(v: Double) = assertEquals(v, node.depth, 0.001)
-    fun maxFont(v: Double) = assertEquals(v, node.maxFontSize, 0.01)
-    fun knum(numOfClass: Int) = assertEquals(numOfClass, node.klasses.size)
-    fun kl(klass: CssClass) = assertTrue(node.klasses.contains(klass))
-    fun style(st: CssStyle) = assertEquals(st, node.style)
-    fun child(idx: Int) = node.children[idx]
-    /*
-        Span {children: Array(2), attributes: Object, classes: ["mord"],
-         depth: 0, height: 0.8141079999999999, maxFontSize: 1, style:{}}
-     */
-
-    // short cut of assertSpan(child(n)) {}
-    fun ac(childIndex: Int, body: SpanAsserter.()->Unit) {
-        val next = child(childIndex)
-        assertTrue(next is RNodeSpan)
-        val sym: RNodeSpan = next as RNodeSpan
-        SpanAsserter(sym).body()
-    }
-}
-
-fun assertSpan(node: RenderNode?, body: SpanAsserter.()->Unit) {
-    assertTrue(node is RNodeSpan)
-    val sym: RNodeSpan = node as RNodeSpan
-    SpanAsserter(sym).body()
-}
-
 
 
 class RenderTreeBuilderTest {
@@ -298,4 +250,6 @@ class RenderTreeBuilderTest {
 
         assertTrue(actual.isNotEmpty())
     }
+
+
 }

--- a/app/src/testCommon/java/io/github/karino2/kotlitex/SpanAsserter.kt
+++ b/app/src/testCommon/java/io/github/karino2/kotlitex/SpanAsserter.kt
@@ -1,0 +1,51 @@
+package io.github.karino2.kotlitex
+
+import org.junit.Assert.*
+
+class SymbolAsserter(val node: RNodeSymbol) {
+    fun text(v: String) = assertEquals(v, node.text)
+    fun h(v: Double) = assertEquals(v, node.height, 0.0001)
+    fun depth(v: Double) = assertEquals(v, node.depth, 0.001)
+    fun skew(v: Double) = assertEquals(v, node.skew, 0.0001)
+    fun w(v: Double) = assertEquals(v, node.width, 0.00001)
+    fun maxFont(v: Double) = assertEquals(v, node.maxFontSize, 0.01)
+    fun knum(numOfClass: Int) = assertEquals(numOfClass, node.klasses.size)
+    fun kl(klass: CssClass) = assertTrue(node.klasses.contains(klass))
+}
+
+fun assertSymbol(node: RenderNode?, body: SymbolAsserter.()->Unit) {
+    assertTrue(node is RNodeSymbol)
+    val sym: RNodeSymbol = node as RNodeSymbol
+    SymbolAsserter(sym).body()
+}
+
+class SpanAsserter(val node: RNodeSpan) {
+    fun cnum(numOfChildren: Int) = assertEquals(numOfChildren, node.children.size)
+    fun h(v: Double) = assertEquals(v, node.height, 0.0001)
+    fun depth(v: Double) = assertEquals(v, node.depth, 0.001)
+    fun maxFont(v: Double) = assertEquals(v, node.maxFontSize, 0.01)
+    fun knum(numOfClass: Int) = assertEquals(numOfClass, node.klasses.size)
+    fun kl(klass: CssClass) = assertTrue(node.klasses.contains(klass))
+    fun style(st: CssStyle) = assertEquals(st, node.style)
+    fun styleTop(top: String) = assertEquals(top, node.style.top)
+    fun child(idx: Int) = node.children[idx]
+    /*
+        Span {children: Array(2), attributes: Object, classes: ["mord"],
+         depth: 0, height: 0.8141079999999999, maxFontSize: 1, style:{}}
+     */
+
+    // short cut of assertSpan(child(n)) {}
+    fun ac(childIndex: Int, body: SpanAsserter.()->Unit) {
+        val next = child(childIndex)
+        assertTrue(next is RNodeSpan)
+        val sym: RNodeSpan = next as RNodeSpan
+        SpanAsserter(sym).body()
+    }
+}
+
+fun assertSpan(node: RenderNode?, body: SpanAsserter.()->Unit) {
+    assertTrue(node is RNodeSpan)
+    val sym: RNodeSpan = node as RNodeSpan
+    SpanAsserter(sym).body()
+}
+


### PR DESCRIPTION
Fix #59.
The order of return value was wrong, but JS version use destructuring assignment for object notation, so they are OK but we are not.

We need to share some assert builder code for unit test and instrumentation test.
So I create testCommon folder for both utility.
