### PR TITLE
Fixes #70. Add mfrac class handling.

### DIFF
--- a/app/src/main/java/io/github/karino2/kotlitex/renderer/node/ClassStateMapping.kt
+++ b/app/src/main/java/io/github/karino2/kotlitex/renderer/node/ClassStateMapping.kt
@@ -50,6 +50,9 @@ object ClassStateMapping {
                 state.vlist.addCell(lineNode)
                 return state.withResetMargin()
             }
+            CssClass.mfrac -> {
+                state.copy(textAlign = Alignment.CENTER)
+            }
             else -> state
         }
     }


### PR DESCRIPTION
Now align center is not default and we need to add center for numerator of frac.