### PR TITLE
Explicitly ignore Alignment.NONE (for ktlint).

### DIFF
--- a/app/src/main/java/io/github/karino2/kotlitex/renderer/node/VirtualCanvasNode.kt
+++ b/app/src/main/java/io/github/karino2/kotlitex/renderer/node/VirtualCanvasNode.kt
@@ -152,6 +152,7 @@ class VerticalList(var alignment: Alignment, var rowStart: Double, klasses: Set<
             Alignment.LEFT -> leftAlign()
             Alignment.CENTER -> centerAlign()
             Alignment.RIGHT -> rightAlign()
+            Alignment.NONE -> {}
         }
     }
 


### PR DESCRIPTION
Just for ktlint warning.