### PR TITLE
Fix sqrt width.

### DIFF
--- a/app/src/main/java/io/github/karino2/kotlitex/renderer/VirtualNodeBuilder.kt
+++ b/app/src/main/java/io/github/karino2/kotlitex/renderer/VirtualNodeBuilder.kt
@@ -82,7 +82,8 @@ class VirtualNodeBuilder(val children: List<RenderNode>, baseSize: Double, val h
 
     private fun createTextNode(node: RenderNode) {
         if (node is RNodeSymbol) {
-            if (node.text.length > 0) {
+            val isZeroWidthSpace = (node.text.length == 1 && node.text[0] == '\u200B')
+            if (node.text.length > 0 && !isZeroWidthSpace) {
                 val s = this.state
                 val textNode = TextNode(node.text, CssFont(CssFontFamily.SERIF, state.fontSize()), state.color, state.klasses)
 

--- a/app/src/main/java/io/github/karino2/kotlitex/renderer/node/VirtualCanvasNode.kt
+++ b/app/src/main/java/io/github/karino2/kotlitex/renderer/node/VirtualCanvasNode.kt
@@ -109,7 +109,7 @@ class VerticalListRow(klasses: Set<String>) : VirtualContainerNode<VirtualCanvas
 }
 
 abstract class StretchyNode(val minWidth: Double, klasses: Set<String>) : VirtualCanvasNode(klasses) {
-    fun setListWidth(width: Double) {
+    open fun setListWidth(width: Double) {
         bounds.width = width + this.minWidth
     }
 }
@@ -228,4 +228,11 @@ class HPaddingNode(klasses: Set<String>) : VirtualCanvasNode(klasses)
 class HorizontalLineNode(val color: String, minWidth: Double, klasses: Set<String>) : StretchyNode(minWidth, klasses)
 
 // SvgNode in canvas-latex. Note that there is the same class-name in katex (but this class is counter-part of canvas-latex, not katex).
-class PathNode(val rnode: RNodePathHolder, minWidth: Double, klasses: Set<String>) : StretchyNode(minWidth, klasses)
+class PathNode(val rnode: RNodePathHolder, minWidth: Double, klasses: Set<String>) : StretchyNode(minWidth, klasses) {
+    override fun setListWidth(width: Double) {
+        bounds.width = width
+        // in original implementation, they also update width of virtualHtmlNode.attributes here.
+        // But I think we do not use it.
+    }
+
+}

--- a/app/src/main/java/io/github/karino2/kotlitex/renderer/node/VirtualCanvasNode.kt
+++ b/app/src/main/java/io/github/karino2/kotlitex/renderer/node/VirtualCanvasNode.kt
@@ -234,5 +234,4 @@ class PathNode(val rnode: RNodePathHolder, minWidth: Double, klasses: Set<String
         // in original implementation, they also update width of virtualHtmlNode.attributes here.
         // But I think we do not use it.
     }
-
 }


### PR DESCRIPTION
Fixes #43. SvgNode should have override setListWidth but we didn't.
We override it.

Also, there are zero width space node.
Handling them change no observable change. But I make it the same as canvas-latex.