### PR TITLE
Use Build Matrix to run fast (unit) tests separately

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,15 +10,13 @@ env:
     - TARGET=unit
     - TARGET=instrumentation
 
-before_install:
+install:
   # Install SDK license so Android Gradle plugin can install deps.
   - mkdir "$ANDROID_HOME/licenses" || true
   - echo "d56f5187479451eabf01fb78af6dfcb131a6481e" > "$ANDROID_HOME/licenses/android-sdk-license"
   - echo "24333f8a63b6825ea9c5514f83c2829b004d1fee" >> "$ANDROID_HOME/licenses/android-sdk-license"
   # Install the rest of tools (e.g., avdmanager)
   - sdkmanager tools
-
-install: ./gradlew clean assemble assembleAndroidTest --stacktrace
 
 script: ./build.sh
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,9 @@ language: android
 env:
   global:
     - ADB_INSTALL_TIMEOUT=10 # minutes
+  matrix:
+    - TARGET=unit
+    - TARGET=instrumentation
 
 before_install:
   # Install SDK license so Android Gradle plugin can install deps.
@@ -14,19 +17,10 @@ before_install:
   - echo "24333f8a63b6825ea9c5514f83c2829b004d1fee" >> "$ANDROID_HOME/licenses/android-sdk-license"
   # Install the rest of tools (e.g., avdmanager)
   - sdkmanager tools
-  # Install the system image
-  - sdkmanager "system-images;android-21;google_apis;armeabi-v7a"
-  # Create and start emulator for the script. Meant to race the install task.
-  - echo no | avdmanager create avd --force -n test -k "system-images;android-21;google_apis;armeabi-v7a"
-  - $ANDROID_HOME/emulator/emulator -avd test -no-audio -no-window &
 
 install: ./gradlew clean assemble assembleAndroidTest --stacktrace
 
-before_script:
-  - android-wait-for-emulator
-  - adb shell input keyevent 82
-
-script: ./gradlew ktlint test connectedCheck --stacktrace
+script: ./build.sh
 
 before_cache:
   - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,19 @@
+#! /bin/sh
+
+spec='system-images;android-21;google_apis;armeabi-v7a'
+
+case "$TARGET" in
+    unit)
+        ./gradlew ktlint test --stacktrace
+        ;;
+    instrumentation)
+        # Install the system image
+        sdkmanager "$spec"
+        # Create and start emulator for the script.
+        echo no | avdmanager create avd --force -n test -k "$spec"
+        $ANDROID_HOME/emulator/emulator -avd test -no-audio -no-window &
+        android-wait-for-emulator
+        adb shell input keyevent 82
+        ./gradlew connectedCheck --stacktrace
+        ;;
+esac

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,13 @@
 # http://www.gradle.org/docs/current/userguide/build_environment.html
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
-org.gradle.jvmargs=-Xmx1536m
+
+# Run Dex in-process
+# https://medium.com/google-developers/faster-android-studio-builds-with-dex-in-process-5988ed8aa37e
+# https://medium.com/asos-techblog/exploring-the-android-build-process-demystifying-gradle-flags-74334255462
+org.gradle.jvmargs=-Xmx2048m
+
+
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects


### PR DESCRIPTION
These changes don't make the build faster sadly, but at least we can run fast (unit) tests separately and see the result.