### PR TITLE
Handle variants

### DIFF
--- a/kotlitex/src/androidTest/java/io/github/karino2/kotlitex/renderer/AndroidFontLoaderTest.kt
+++ b/kotlitex/src/androidTest/java/io/github/karino2/kotlitex/renderer/AndroidFontLoaderTest.kt
@@ -10,10 +10,14 @@ import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
 class AndroidFontLoaderTest {
+    private fun createLoader(): FontLoader {
+        val ctx = InstrumentationRegistry.getTargetContext()
+        return AndroidFontLoader(ctx.assets)
+    }
+
     @Test
     fun measureTextWidth() {
-        val ctx = InstrumentationRegistry.getTargetContext()
-        val loader = AndroidFontLoader(ctx.assets)
+        val loader = createLoader()
         val font = CssFont("KaTeX_Math", 10.0)
         assertEquals(6.0, loader.measureTextWidth(font, "x"), 0.01)
         assertEquals(22.0, loader.measureTextWidth(font, "hello"), 0.01)
@@ -21,9 +25,14 @@ class AndroidFontLoaderTest {
 
     @Test
     fun toTypefaceIsFlyweight() {
-        val ctx = InstrumentationRegistry.getTargetContext()
-        val loader = AndroidFontLoader(ctx.assets)
+        val loader = createLoader()
         val font = CssFont("KaTeX_Math", 10.0)
         assertEquals(loader.toTypeface(font), loader.toTypeface(font))
+    }
+
+    @Test
+    fun fontToTypefaceMapKeyHandleNormal() {
+        val font = CssFont("KaTeX_Main", "Normal", 10.0)
+        assertEquals("KaTeX_Main-Regular", AndroidFontLoader.fontToTypefaceMapKey(font))
     }
 }

--- a/kotlitex/src/androidTest/java/io/github/karino2/kotlitex/renderer/AndroidFontLoaderTest.kt
+++ b/kotlitex/src/androidTest/java/io/github/karino2/kotlitex/renderer/AndroidFontLoaderTest.kt
@@ -14,7 +14,7 @@ class AndroidFontLoaderTest {
     fun measureTextWidth() {
         val ctx = InstrumentationRegistry.getTargetContext()
         val loader = AndroidFontLoader(ctx.assets)
-        val font = CssFont.create("KaTeX_Math", "", 10.0)
+        val font = CssFont("KaTeX_Math", 10.0)
         assertEquals(6.0, loader.measureTextWidth(font, "x"), 0.01)
         assertEquals(22.0, loader.measureTextWidth(font, "hello"), 0.01)
     }
@@ -23,7 +23,7 @@ class AndroidFontLoaderTest {
     fun toTypefaceIsFlyweight() {
         val ctx = InstrumentationRegistry.getTargetContext()
         val loader = AndroidFontLoader(ctx.assets)
-        val font = CssFont.create("KaTeX_Math", "", 10.0)
+        val font = CssFont("KaTeX_Math", 10.0)
         assertEquals(loader.toTypeface(font), loader.toTypeface(font))
     }
 }

--- a/kotlitex/src/main/java/io/github/karino2/kotlitex/renderer/FontLoader.kt
+++ b/kotlitex/src/main/java/io/github/karino2/kotlitex/renderer/FontLoader.kt
@@ -4,7 +4,6 @@ import android.content.res.AssetManager
 import android.graphics.Paint
 import android.graphics.Typeface
 import io.github.karino2.kotlitex.renderer.node.CssFont
-import io.github.karino2.kotlitex.renderer.node.CssFontFamily
 
 interface FontLoader {
     fun measureTextWidth(font: CssFont, text: String): Double
@@ -15,29 +14,29 @@ class AndroidFontLoader(private val assetManager: AssetManager) :
     FontLoader {
     private val typefaceMap =
         listOf(
-            "AMS-Regular",
-            "Caligraphic-Bold",
-            "Caligraphic-Regular",
-            "Fraktur-Bold",
-            "Fraktur-Regular",
-            "Main-Bold",
-            "Main-BoldItalic",
-            "Main-Italic",
-            "Main-Regular",
-            "Math-BoldItalic",
-            "Math-Italic",
-            "Math-Regular",
-            "SansSerif-Bold",
-            "SansSerif-Italic",
-            "SansSerif-Regular",
-            "Script-Regular",
-            "Size1-Regular",
-            "Size2-Regular",
-            "Size3-Regular",
-            "Size4-Regular",
-            "Typewriter-Regular"
+            "KaTeX_AMS-Regular",
+            "KaTeX_Caligraphic-Bold",
+            "KaTeX_Caligraphic-Regular",
+            "KaTeX_Fraktur-Bold",
+            "KaTeX_Fraktur-Regular",
+            "KaTeX_Main-Bold",
+            "KaTeX_Main-BoldItalic",
+            "KaTeX_Main-Italic",
+            "KaTeX_Main-Regular",
+            "KaTeX_Math-BoldItalic",
+            "KaTeX_Math-Italic",
+            "KaTeX_Math-Regular",
+            "KaTeX_SansSerif-Bold",
+            "KaTeX_SansSerif-Italic",
+            "KaTeX_SansSerif-Regular",
+            "KaTeX_Script-Regular",
+            "KaTeX_Size1-Regular",
+            "KaTeX_Size2-Regular",
+            "KaTeX_Size3-Regular",
+            "KaTeX_Size4-Regular",
+            "KaTeX_Typewriter-Regular"
             ).map {
-            it to Typeface.createFromAsset(assetManager, "fonts/KaTeX_$it.ttf")
+            it to Typeface.createFromAsset(assetManager, "fonts/$it.ttf")
         }.toMap()
 
     override fun measureTextWidth(font: CssFont, text: String): Double {
@@ -47,11 +46,15 @@ class AndroidFontLoader(private val assetManager: AssetManager) :
         return paint.measureText(text).toDouble()
     }
 
-    override fun toTypeface(font: CssFont): Typeface {
-        return when (font.family) {
-            CssFontFamily.KaTeX_Size2 -> typefaceMap["Size2-Regular"]!!
-            CssFontFamily.Math_Italic -> typefaceMap["Math-Italic"]!!
-            else -> typefaceMap["Main-Regular"]!!
+    private fun fontToTypefaceMapKey(font: CssFont): String {
+        var variant = font.variant.capitalize()
+        if (variant.isEmpty()) {
+            variant = "Regular"
         }
+        return "${font.family}-$variant"
+    }
+
+    override fun toTypeface(font: CssFont): Typeface {
+        return typefaceMap.getValue(fontToTypefaceMapKey(font))
     }
 }

--- a/kotlitex/src/main/java/io/github/karino2/kotlitex/renderer/FontLoader.kt
+++ b/kotlitex/src/main/java/io/github/karino2/kotlitex/renderer/FontLoader.kt
@@ -46,12 +46,14 @@ class AndroidFontLoader(private val assetManager: AssetManager) :
         return paint.measureText(text).toDouble()
     }
 
-    private fun fontToTypefaceMapKey(font: CssFont): String {
-        var variant = font.variant.capitalize()
-        if (variant.isEmpty()) {
-            variant = "Regular"
+    companion object {
+        fun fontToTypefaceMapKey(font: CssFont): String {
+            var variant = font.variant.capitalize()
+            if (variant.isEmpty() || variant == "Normal") {
+                variant = "Regular"
+            }
+            return "${font.family}-$variant"
         }
-        return "${font.family}-$variant"
     }
 
     override fun toTypeface(font: CssFont): Typeface {

--- a/kotlitex/src/main/java/io/github/karino2/kotlitex/renderer/VirtualNodeBuilder.kt
+++ b/kotlitex/src/main/java/io/github/karino2/kotlitex/renderer/VirtualNodeBuilder.kt
@@ -84,7 +84,7 @@ class VirtualNodeBuilder(val children: List<RenderNode>, baseSize: Double, val f
             val isZeroWidthSpace = (node.text.length == 1 && node.text[0] == '\u200B')
             if (node.text.length > 0 && !isZeroWidthSpace) {
                 val s = this.state
-                val textNode = TextNode(fontLoader, node.text, CssFont.create(state.family, state.variant, state.fontSize()), state.color, state.klasses)
+                val textNode = TextNode(fontLoader, node.text, CssFont(state.family, state.variant, state.fontSize()), state.color, state.klasses)
                 textNode.updateSize()
                 textNode.setPosition(s.nextX(), s.y)
                 textNode.margin.left = s.marginLeft

--- a/kotlitex/src/main/java/io/github/karino2/kotlitex/renderer/node/CssFont.kt
+++ b/kotlitex/src/main/java/io/github/karino2/kotlitex/renderer/node/CssFont.kt
@@ -1,26 +1,9 @@
 package io.github.karino2.kotlitex.renderer.node
 
-enum class CssFontFamily {
-    SERIF,
-    KaTeX_Size2,
-    Math_Italic,
-    Main_Regular
-}
-
 /**
  * This class is designed to 1) run unit tests without mocking Android classes such as Typesafe and
  * 2) make the structure similar to canvas-latex.
  */
-data class CssFont(val family: CssFontFamily, val size: Double) {
-    companion object {
-        fun create(fami: String, variant: String, size: Double): CssFont {
-            val family = when (fami) {
-                "KaTeX_Size2" -> CssFontFamily.KaTeX_Size2
-                // TODO: should care variant.
-                "KaTeX_Math" -> CssFontFamily.Math_Italic
-                else -> CssFontFamily.Main_Regular
-            }
-            return CssFont(family, size)
-        }
-    }
+data class CssFont(val family: String, val variant: String, val size: Double) {
+    constructor(family: String, size: Double) : this(family, "", size)
 }

--- a/kotlitex/src/test/java/io/github/karino2/kotlitex/renderer/node/CssFontTest.kt
+++ b/kotlitex/src/test/java/io/github/karino2/kotlitex/renderer/node/CssFontTest.kt
@@ -1,0 +1,12 @@
+package io.github.karino2.kotlitex.renderer.node
+
+import org.junit.Assert.*
+import org.junit.Test
+
+class CssFontTest {
+    @Test
+    fun createWithoutVariant() {
+        val font = CssFont("serif", 12.0)
+        assertEquals("", font.variant)
+    }
+}


### PR DESCRIPTION
Instead of having CssFontFamily, CssFont can have its family as String.