### PR TITLE
Fix size2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.3.1'
+        classpath 'com.android.tools.build:gradle:3.3.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/kotlitex/src/main/java/io/github/karino2/kotlitex/MathExpressionSpan.kt
+++ b/kotlitex/src/main/java/io/github/karino2/kotlitex/MathExpressionSpan.kt
@@ -4,11 +4,14 @@ import android.content.res.AssetManager
 import android.graphics.*
 import android.graphics.drawable.Drawable
 import android.text.TextPaint
-import android.text.style.DynamicDrawableSpan
+import android.text.style.ReplacementSpan
+import android.util.Log
 import io.github.karino2.kotlitex.renderer.AndroidFontLoader
 import io.github.karino2.kotlitex.renderer.FontLoader
 import io.github.karino2.kotlitex.renderer.VirtualNodeBuilder
 import io.github.karino2.kotlitex.renderer.node.*
+import java.lang.ref.WeakReference
+import kotlin.math.roundToInt
 
 
 private class MathExpressionDrawable(expr: String, baseSize: Float, val fontLoader: FontLoader, val drawBounds: Boolean = false) : Drawable() {
@@ -37,7 +40,7 @@ private class MathExpressionDrawable(expr: String, baseSize: Float, val fontLoad
     }
 
     override fun draw(canvas: Canvas) {
-        drawRenderNodes(canvas, rootNode)
+        drawRenderNodes(canvas, rootNode, 1.0f)
     }
 
     // TODO
@@ -50,51 +53,52 @@ private class MathExpressionDrawable(expr: String, baseSize: Float, val fontLoad
         return y.toFloat() + 200
     }
 
-    private fun drawBounds(canvas: Canvas, bounds: Bounds) {
+    private fun drawBounds(canvas: Canvas, bounds: Bounds, ratio: Float) {
         if (! drawBounds) {
             return
         }
 
-        val x = translateX(bounds.x)
-        val y = translateY(bounds.y)
+        val x = translateX(bounds.x)*ratio
+        val y = translateY(bounds.y)*ratio
 
         paint.color = Color.RED
         paint.strokeWidth = 1.0f
         paint.style = Paint.Style.STROKE
 
         // TODO: This doesn't look right though...
-        canvas.drawRect(RectF(x, y - bounds.height.toFloat(), x + bounds.width.toFloat(), y), paint)
+        // canvas.drawRect(RectF(x, y - bounds.height.toFloat()*ratio, x + bounds.width.toFloat()*ratio, y), paint)
+        canvas.drawRect(RectF(x, y - bounds.height.toFloat()*ratio, x + bounds.width.toFloat()*ratio, y + bounds.height.toFloat()*ratio), paint)
     }
 
-    private fun drawRenderNodes(canvas: Canvas, parent: VirtualCanvasNode) {
+    private fun drawRenderNodes(canvas: Canvas, parent: VirtualCanvasNode, ratio: Float) {
         when (parent) {
             is VirtualContainerNode<*> -> {
                 parent.nodes.forEach {
-                    drawRenderNodes(canvas, it)
+                    drawRenderNodes(canvas, it, ratio)
                 }
             }
             is TextNode -> {
                 // TODO: temp font test.
                 textPaint.typeface = fontLoader.toTypeface(parent.font)
-                textPaint.textSize = parent.font.size.toFloat()
-                val x = translateX(parent.bounds.x)
-                val y = translateY(parent.bounds.y)
+                textPaint.textSize = parent.font.size.toFloat()*ratio
+                val x = translateX(parent.bounds.x)*ratio
+                val y = translateY(parent.bounds.y)*ratio
                 canvas.drawText(parent.text, x, y, textPaint)
-                drawBounds(canvas, parent.bounds)
+                drawBounds(canvas, parent.bounds, ratio)
             }
             is HorizontalLineNode -> {
                 paint.color = Color.BLACK
-                paint.strokeWidth = parent.bounds.height.toFloat()
-                val x = translateX(parent.bounds.x)
-                val y = translateY(parent.bounds.y)
-                canvas.drawLine(x, y, x + parent.bounds.width.toFloat(), y, paint)
-                drawBounds(canvas, parent.bounds)
+                paint.strokeWidth = parent.bounds.height.toFloat()*ratio
+                val x = translateX(parent.bounds.x)*ratio
+                val y = translateY(parent.bounds.y)*ratio
+                canvas.drawLine(x, y, x + parent.bounds.width.toFloat()*ratio, y, paint)
+                drawBounds(canvas, parent.bounds, ratio)
             }
             is PathNode -> {
-                val x = translateX(parent.bounds.x)
-                val y = (translateY(parent.bounds.y) - parent.bounds.height).toFloat()
+                val x = translateX(parent.bounds.x)*ratio
+                val y = (translateY(parent.bounds.y) - parent.bounds.height).toFloat()*ratio
 
-                drawBounds(canvas, parent.bounds)
+                drawBounds(canvas, parent.bounds, ratio)
 
 
                 // TODO: support other preserve aspect ratio.
@@ -102,7 +106,9 @@ private class MathExpressionDrawable(expr: String, baseSize: Float, val fontLoad
                 val mat = Matrix()
 
                 val heightvb = parent.rnode.viewBox.height
-                val (_, _, wb, hb) = parent.bounds
+                val (_, _, wbVirtual, hbVirtual) = parent.bounds
+                val wb = wbVirtual*ratio
+                val hb = hbVirtual*ratio
 
                 // this is preserveAspectRatio = meet
                 /*
@@ -142,14 +148,112 @@ private class MathExpressionDrawable(expr: String, baseSize: Float, val fontLoad
         }
     }
 
+    fun drawWithRatio(canvas: Canvas, ratio: Float) {
+        drawRenderNodes(canvas, rootNode, ratio)
+    }
+
 }
 
-class MathExpressionSpan(val expr: String, val baseSize: Float = 44.0f, val assetManager: AssetManager) : DynamicDrawableSpan() {
-    override fun getDrawable(): Drawable {
+// Similar to DynamicDrawableSpan, but getSize is a little different.
+// I create super class of DynamicDrawableSpan because getCachedDrawable is private and we neet it.
+class MathExpressionSpan(val expr: String, val baseHeightSpecified: Float?, val assetManager: AssetManager) : ReplacementSpan() {
+    enum class Align {
+        Bottom, BaseLine
+    }
+
+    var verticalAlignment = Align.Bottom
+
+    override fun getSize(paint: Paint, text: CharSequence?, start: Int, end: Int, fm: Paint.FontMetricsInt?): Int {
+        val d = getCachedDrawable()
+        val rect = d.bounds
+
+        baseHeightSpecified?.let { targetHeight ->
+            val ratio = targetHeight/virtualBaseHeight
+            if(fm == null) {
+                return (rect.right*ratio).roundToInt()
+            }
+
+
+            val lineNum = rect.bottom/virtualBaseHeight
+            // We follow DynamicDrawableSpan logic. But it's a little different from no-size specified case.
+            fm.ascent = -(lineNum*targetHeight).roundToInt()
+            fm.descent = 0
+            fm.top = fm.ascent
+            fm.bottom = 0
+            // should we roundUp?
+            return (rect.right*ratio).roundToInt()
+        }
+        // below here is baseHeightSpecified == null case.
+
+        if(fm != null) {
+            // TODO: consider handling of baseline.
+            // I think we should align drawable's drawRenderNode baseline to fm.baseline.
+            // But our font is different, so it's not obvious whether my assumption is correct.
+            // Currently, I just use whole height as our box height.
+
+
+            // fm.bottom and top seems zero. There seems no way to know current line height.
+            /*
+            val lineHeight = fm.bottom - fm.top
+            // sometime, bottom and top is zero. in this case, we regard
+            val ratio = if(lineHeight == 0) 1.0 else lineHeight/ rect.bottom.toDouble()
+
+            // should we roundup?
+            return (rect.right*ratio).roundToInt()
+             */
+            fm.ascent = -rect.bottom
+            fm.descent = 0
+            fm.top = fm.ascent
+            fm.bottom
+        }
+
+        return rect.right
+    }
+
+    override fun draw(
+        canvas: Canvas,
+        text: CharSequence?,
+        start: Int,
+        end: Int,
+        x: Float,
+        top: Int,
+        y: Int,
+        bottom: Int,
+        paint: Paint
+    ) {
+        val b = getCachedDrawable()
+
+        // We always use full height. So we do not need any alignment, right?
+        val ratio = (bottom-top).toDouble() / b.bounds.bottom.toDouble()
+        Log.d("kotlitex", "ratio=$ratio")
+
+
+
+        canvas.save()
+        canvas.translate(x, top.toFloat())
+        b.drawWithRatio(canvas, ratio.toFloat())
+
+        canvas.restore()
+    }
+    val virtualBaseHeight = 100.0f
+
+    private fun getDrawable(): MathExpressionDrawable {
         // TODO: drawBounds should be always false. Unlike baseSize, we don't have to expose the flag to end-users.
-        val drawable = MathExpressionDrawable(expr, baseSize,
+        val drawable = MathExpressionDrawable(expr, virtualBaseHeight,
             AndroidFontLoader(assetManager), drawBounds = true)
-        drawable.setBounds(drawable.bounds.left, drawable.bounds.top, drawable.getIntrinsicWidth(), drawable.getIntrinsicHeight());
+        drawable.setBounds(drawable.bounds.left, drawable.bounds.top, drawable.intrinsicWidth, drawable.intrinsicHeight);
         return drawable
     }
+
+    private fun getCachedDrawable() : MathExpressionDrawable {
+        val wr = drawableRef
+        val d = wr?.get()
+        if (d != null)
+            return d
+        val newDrawable = getDrawable()
+        drawableRef = WeakReference(newDrawable)
+        return newDrawable
+    }
+
+    private var drawableRef : WeakReference<MathExpressionDrawable>? = null
 }

--- a/sample/src/main/java/io/github/karino2/kotlitex/sample/MainActivity.kt
+++ b/sample/src/main/java/io/github/karino2/kotlitex/sample/MainActivity.kt
@@ -4,26 +4,31 @@ import android.support.v7.app.AppCompatActivity
 import android.os.Bundle
 import android.text.Spannable
 import android.text.SpannableStringBuilder
+import android.util.Log
 import android.widget.TextView
 import io.github.karino2.kotlitex.MathExpressionSpan
 
 class MainActivity : AppCompatActivity() {
-    private val BIGGER_SIZE_FOR_DEBUGGING = 100.0f
+
+    // private val PHYSICAL_BASE_SIZE = 100.0f // big size for debug
+    private val PHYSICAL_BASE_SIZE = 42f // textView.textSize
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
 
         val textView = findViewById<TextView>(R.id.textView)
+        Log.d("kotlitex", "textSize = ${textView.textSize}")
         val spannable = SpannableStringBuilder("01234567 91 345 789 234 678 and the remaining text.")
 
-        spannable.setSpan(createMathSpan("x^2", BIGGER_SIZE_FOR_DEBUGGING), 0, 2, Spannable.SPAN_INCLUSIVE_EXCLUSIVE)
-        spannable.setSpan(createMathSpan("\\frac{1}{2}", BIGGER_SIZE_FOR_DEBUGGING), 2, 4, Spannable.SPAN_INCLUSIVE_EXCLUSIVE)
-        spannable.setSpan(createMathSpan("\\sqrt{3}", BIGGER_SIZE_FOR_DEBUGGING), 4, 6, Spannable.SPAN_INCLUSIVE_EXCLUSIVE)
-        spannable.setSpan(createMathSpan("\\frac{1}{1+\\frac{1}{x^2}}", BIGGER_SIZE_FOR_DEBUGGING), 6, 8, Spannable.SPAN_INCLUSIVE_EXCLUSIVE)
-        spannable.setSpan(createMathSpan("\\sum^N_{k=1} k", BIGGER_SIZE_FOR_DEBUGGING), 22, 25, Spannable.SPAN_INCLUSIVE_EXCLUSIVE)
+        spannable.setSpan(createMathSpan("x^2", PHYSICAL_BASE_SIZE), 0, 2, Spannable.SPAN_INCLUSIVE_EXCLUSIVE)
+        spannable.setSpan(createMathSpan("\\frac{1}{2}", PHYSICAL_BASE_SIZE), 2, 4, Spannable.SPAN_INCLUSIVE_EXCLUSIVE)
+        spannable.setSpan(createMathSpan("\\sqrt{3}", PHYSICAL_BASE_SIZE), 4, 6, Spannable.SPAN_INCLUSIVE_EXCLUSIVE)
+        spannable.setSpan(createMathSpan("\\frac{1}{1+\\frac{1}{x^2}}", PHYSICAL_BASE_SIZE), 6, 8, Spannable.SPAN_INCLUSIVE_EXCLUSIVE)
+        spannable.setSpan(createMathSpan("\\sum^N_{k=1} k", PHYSICAL_BASE_SIZE), 22, 25, Spannable.SPAN_INCLUSIVE_EXCLUSIVE)
         textView.text = spannable
     }
 
     fun createMathSpan(expr: String, baseSize: Float) = MathExpressionSpan(expr, baseSize, assets)
+//    fun createMathSpan(expr: String, baseSize: Float) = MathExpressionSpan(expr, null, assets)
 }

--- a/sample/src/main/java/io/github/karino2/kotlitex/sample/MainActivity.kt
+++ b/sample/src/main/java/io/github/karino2/kotlitex/sample/MainActivity.kt
@@ -11,7 +11,8 @@ import io.github.karino2.kotlitex.MathExpressionSpan
 class MainActivity : AppCompatActivity() {
 
     // private val PHYSICAL_BASE_SIZE = 100.0f // big size for debug
-    private val PHYSICAL_BASE_SIZE = 42f // textView.textSize
+    private val PHYSICAL_BASE_SIZE = 42f // textView.textSize, 14sp in my device.
+    // private val PHYSICAL_BASE_SIZE = 72f // 24sp
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)

--- a/sample/src/main/res/layout/activity_main.xml
+++ b/sample/src/main/res/layout/activity_main.xml
@@ -14,6 +14,7 @@
             android:layout_marginBottom="8dp" app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintTop_toTopOf="parent" app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintBottom_toBottomOf="parent"
-            android:layout_marginStart="8dp" android:layout_marginEnd="8dp"/>
+            android:layout_marginStart="8dp" android:layout_marginEnd="8dp" android:text="Hello"
+            android:textSize="24sp"/>
 
 </android.support.constraint.ConstraintLayout>


### PR DESCRIPTION
Fix #68.
Now MathExpressionSpan seems sizing itself correctly.

But TextView side fail to recognize height if MathExpressionSpan is higher than specified size.

1. translateX, translateY seems obsolete now, but keep it because I'm not sure
2. Now MathExpressionDrawable is not the subclass of Drawable. It make code easier to understand, though the name is a little misleading