### PR TITLE
Implement math supported text view.

### DIFF
--- a/kotlitex/build.gradle
+++ b/kotlitex/build.gradle
@@ -13,6 +13,12 @@ android {
         versionName "1.0"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
+
+    // for workaround https://github.com/Kotlin/kotlinx.coroutines/issues/1059
+    packagingOptions {
+        exclude 'META-INF/atomicfu.kotlin_module'
+    }
+    
     buildTypes {
         release {
             minifyEnabled false
@@ -36,6 +42,7 @@ dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation"org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation 'com.android.support:appcompat-v7:28.0.0'
+    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.2.0-alpha'
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'com.android.support.test:runner:1.0.2'
     androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'

--- a/kotlitex/src/main/java/io/github/karino2/kotlitex/MarkdownView.kt
+++ b/kotlitex/src/main/java/io/github/karino2/kotlitex/MarkdownView.kt
@@ -1,0 +1,122 @@
+package io.github.karino2.kotlitex
+
+import android.content.Context
+import android.content.res.AssetManager
+import android.text.Spannable
+import android.text.SpannableStringBuilder
+import android.util.AttributeSet
+import android.widget.TextView
+import kotlinx.coroutines.*
+
+interface MathSpanHandler {
+    fun appendNormal(text: String)
+    fun appendMathExp(exp: String)
+    fun appendMathLineExp(text: String)
+    fun appendEndOfLine()
+}
+
+// to make this class unit testable.
+class MathSpanBuilder(val handler: MathSpanHandler) {
+    val builder = SpannableStringBuilder()
+
+    val mathExpLinePat = "^\\$\\$(.*)\\$\\$\$".toRegex()
+    val mathExpPat = "\\$\\$([^$]+)\\$\\$".toRegex()
+    // val mathExpPat = "\\$\\$(.*)\$\$".toRegex()
+
+    fun oneNormalLineWithoutEOL(line: String) {
+        if(line.isEmpty())
+            return
+
+        var lastMatchPos = 0
+        var res = mathExpPat.find(line)
+        if(res == null) {
+            handler.appendNormal(line)
+            return
+        }
+
+        while(res != null) {
+            if(lastMatchPos != res.range.start)
+                handler.appendNormal(line.substring(lastMatchPos, res.range.start))
+            handler.appendMathExp(res.groupValues[1])
+            lastMatchPos = res.range.last+1
+            res = res.next()
+        }
+        if(lastMatchPos != line.length)
+            handler.appendNormal(line.substring(lastMatchPos))
+    }
+
+    fun oneLine(line:String) {
+        mathExpLinePat.matchEntire(line)?.let {
+            handler.appendMathLineExp(it.groupValues[1])
+            return
+        }
+        oneNormalLineWithoutEOL(line)
+        handler.appendEndOfLine()
+    }
+
+}
+
+class SpannableMathSpanHandler(val assetManager: AssetManager, val baseSize: Float) : MathSpanHandler {
+    fun reset() {
+        // spannable.clear() seems slow.
+        spannable = SpannableStringBuilder()
+    }
+
+    override fun appendNormal(text: String) {
+        spannable.append(text)
+    }
+
+    override fun appendMathExp(exp: String) {
+        appendMathSpan(exp, false)
+    }
+
+    private fun appendMathSpan(exp: String, isMathMode: Boolean) {
+        val span = MathExpressionSpan(exp, baseSize, assetManager, isMathMode)
+        val begin = spannable.length
+        spannable.append("\$\$${exp}\$\$")
+        spannable.setSpan(span, begin, spannable.length, Spannable.SPAN_INCLUSIVE_EXCLUSIVE)
+    }
+
+    override fun appendMathLineExp(text: String) {
+        appendMathSpan(text, true)
+        spannable.append("\n")
+    }
+
+    override fun appendEndOfLine() {
+        spannable.append("\n")
+    }
+
+    var spannable = SpannableStringBuilder()
+
+
+}
+
+class MarkdownView(context : Context, attrSet: AttributeSet) : TextView(context, attrSet) {
+    var job : Job? = null
+
+    val handler by lazy {
+        SpannableMathSpanHandler(context.assets, textSize)
+    }
+
+    val builder by lazy {
+        MathSpanBuilder(handler)
+    }
+
+    fun setMarkdown(text: String) {
+        job?.let { it.cancel() }
+        handler.reset()
+        setText(text)
+        job = GlobalScope.launch {
+            withContext(Dispatchers.IO) {
+                val lines = text.split("\n")
+                repeat(lines.size) {
+                    val line = lines[it]
+                    builder.oneLine(line)
+                }
+            }
+            setText(handler.spannable)
+        }
+
+    }
+
+}

--- a/kotlitex/src/main/java/io/github/karino2/kotlitex/MarkdownView.kt
+++ b/kotlitex/src/main/java/io/github/karino2/kotlitex/MarkdownView.kt
@@ -60,7 +60,10 @@ class SpannableMathSpanHandler(val assetManager: AssetManager, val baseSize: Flo
     fun reset() {
         // spannable.clear() seems slow.
         spannable = SpannableStringBuilder()
+        isMathExist = false
     }
+
+    var isMathExist = false
 
     override fun appendNormal(text: String) {
         spannable.append(text)
@@ -71,6 +74,7 @@ class SpannableMathSpanHandler(val assetManager: AssetManager, val baseSize: Flo
     }
 
     private fun appendMathSpan(exp: String, isMathMode: Boolean) {
+        isMathExist = true
         val span = MathExpressionSpan(exp, baseSize, assetManager, isMathMode)
         val begin = spannable.length
         spannable.append("\$\$${exp}\$\$")
@@ -114,7 +118,8 @@ class MarkdownView(context : Context, attrSet: AttributeSet) : TextView(context,
                     builder.oneLine(line)
                 }
             }
-            setText(handler.spannable)
+            if(handler.isMathExist)
+                setText(handler.spannable)
         }
 
     }

--- a/kotlitex/src/main/java/io/github/karino2/kotlitex/MathExpressionSpan.kt
+++ b/kotlitex/src/main/java/io/github/karino2/kotlitex/MathExpressionSpan.kt
@@ -2,10 +2,8 @@ package io.github.karino2.kotlitex
 
 import android.content.res.AssetManager
 import android.graphics.*
-import android.graphics.drawable.Drawable
 import android.text.TextPaint
 import android.text.style.ReplacementSpan
-import android.util.Log
 import io.github.karino2.kotlitex.renderer.AndroidFontLoader
 import io.github.karino2.kotlitex.renderer.FontLoader
 import io.github.karino2.kotlitex.renderer.VirtualNodeBuilder
@@ -14,10 +12,10 @@ import java.lang.ref.WeakReference
 import kotlin.math.roundToInt
 
 
-private class MathExpressionDrawable(expr: String, baseSize: Float, val fontLoader: FontLoader, val drawBounds: Boolean = false)  {
+private class MathExpressionDrawable(expr: String, baseSize: Float, val fontLoader: FontLoader, isMathMode: Boolean, val drawBounds: Boolean = false)  {
     var rootNode: VerticalList
     init {
-        val options = Options(Style.DISPLAY)
+        val options = if(isMathMode) Options(Style.DISPLAY) else Options(Style.TEXT)
         val parser = Parser(expr)
         val parsed =  parser.parse()
         val nodes = RenderTreeBuilder.buildExpression(parsed, options, true)
@@ -175,7 +173,7 @@ private class MathExpressionDrawable(expr: String, baseSize: Float, val fontLoad
 
 // Similar to DynamicDrawableSpan, but getSize is a little different.
 // I create super class of DynamicDrawableSpan because getCachedDrawable is private and we neet it.
-class MathExpressionSpan(val expr: String, val baseHeightSpecified: Float?, val assetManager: AssetManager) : ReplacementSpan() {
+class MathExpressionSpan(val expr: String, val baseHeightSpecified: Float?, val assetManager: AssetManager, val isMathMode: Boolean) : ReplacementSpan() {
     enum class Align {
         Bottom, BaseLine
     }
@@ -268,7 +266,7 @@ class MathExpressionSpan(val expr: String, val baseHeightSpecified: Float?, val 
     private fun getDrawable(): MathExpressionDrawable {
         // TODO: drawBounds should be always false. Unlike baseSize, we don't have to expose the flag to end-users.
         val drawable = MathExpressionDrawable(expr, virtualBaseHeight,
-            AndroidFontLoader(assetManager), drawBounds = false)
+            AndroidFontLoader(assetManager), isMathMode, drawBounds = false)
         return drawable
     }
 

--- a/kotlitex/src/test/java/io/github/karino2/kotlitex/renderer/MathSpanBuilderTest.kt
+++ b/kotlitex/src/test/java/io/github/karino2/kotlitex/renderer/MathSpanBuilderTest.kt
@@ -1,0 +1,145 @@
+package io.github.karino2.kotlitex.renderer
+
+import io.github.karino2.kotlitex.MathSpanBuilder
+import io.github.karino2.kotlitex.MathSpanHandler
+import org.junit.Test
+import org.junit.Assert.*
+import org.junit.Before
+
+class MathSpanBuilderTest {
+    class HandlerForTest : MathSpanHandler {
+        var counter = 0
+        val normals = ArrayList<Pair<Int, String>>()
+        val mathLine = ArrayList<Pair<Int, String>>()
+        val mathExps = ArrayList<Pair<Int, String>>()
+        val eols = ArrayList<Int>()
+
+        fun reset() {
+            counter = 0
+            normals.clear()
+            mathLine.clear()
+            mathExps.clear()
+            eols.clear()
+        }
+
+        override fun appendNormal(text: String) {
+            normals.add(Pair(counter++, text))
+        }
+
+        override fun appendMathLineExp(text: String) {
+            mathLine.add(Pair(counter++, text))
+        }
+
+        override fun appendMathExp(exp: String) {
+            mathExps.add(Pair(counter++, exp))
+        }
+
+        override fun appendEndOfLine() {
+            eols.add(counter++)
+        }
+
+    }
+
+    val handler = HandlerForTest()
+
+    val target = MathSpanBuilder(handler)
+
+    @Test
+    fun testMathExpPat_MathLine() {
+        val actual = target.mathExpLinePat.matches("\$\$x^2\$\$")
+        assertTrue(actual)
+    }
+
+    @Test
+    fun testMathExpPat_MathExpButNotMathLineEnd() {
+        val actual = target.mathExpLinePat.matches("\$\$x^2\$\$abc")
+        assertFalse(actual)
+    }
+    @Test
+    fun testMathExpPat_MathExpButNotMathLineBegin() {
+        val actual = target.mathExpLinePat.matches("123\$\$x^2\$\$")
+        assertFalse(actual)
+    }
+
+    @Test
+    fun testMathExpPath() {
+        val actual = target.mathExpPat.find("abc\$\$x_2\$\$")
+        assertNotNull(actual)
+    }
+
+    @Before
+    fun setupHandler() {
+        handler.reset()
+    }
+
+
+    fun Pair<Int, String>.assert(expectPos:Int, expectVal: String) {
+        assertEquals(expectPos, this.first)
+        assertEquals(expectVal, this.second)
+    }
+
+    @Test
+    fun testMathLine() {
+        target.oneLine("\$\$x^2\$\$")
+        handler.mathLine[0].assert(0, "x^2")
+    }
+
+    @Test
+    fun testOneLine_EmptyLine() {
+        target.oneLine("")
+
+        assertTrue(handler.mathLine.isEmpty())
+        assertTrue(handler.mathExps.isEmpty())
+        assertTrue(handler.normals.isEmpty())
+        assertEquals(1, handler.eols.size)
+        assertEquals(0, handler.eols[0])
+    }
+
+
+    @Test
+    fun testOneLine_Mixed() {
+        target.oneLine("abc\$\$x^2\$\$")
+
+        assertTrue(handler.mathLine.isEmpty())
+        assertEquals(1, handler.mathExps.size)
+        assertEquals(1, handler.normals.size)
+        assertEquals(1, handler.eols.size)
+
+        handler.normals[0].assert(0, "abc")
+        handler.mathExps[0].assert(1, "x^2")
+        assertEquals(2, handler.eols[0])
+    }
+
+    @Test
+    fun testOneNormal_normalEnd() {
+        target.oneLine("\$\$x^2\$\$def")
+        handler.normals[0].assert(1, "def")
+        handler.mathExps[0].assert(0, "x^2")
+    }
+
+    @Test
+    fun testOneNormal_complex() {
+        target.oneLine("abc\$\$x^2\$\$def\$\$y_2\$\$ghi")
+
+        assertEquals(3, handler.normals.size)
+        assertEquals(2, handler.mathExps.size)
+
+        handler.normals[0].assert(0, "abc")
+        handler.normals[1].assert(2, "def")
+        handler.normals[2].assert(4, "ghi")
+
+        handler.mathExps[0].assert(1, "x^2")
+        handler.mathExps[1].assert(3, "y_2")
+
+    }
+
+    @Test
+    fun testOneNormal_noMath() {
+        target.oneLine("abc def")
+
+        assertEquals(1, handler.normals.size)
+        assertTrue(handler.mathExps.isEmpty())
+
+        handler.normals[0].assert(0, "abc def")
+    }
+}

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -17,6 +17,11 @@ android {
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
 
     }
+    
+    // for workaround https://github.com/Kotlin/kotlinx.coroutines/issues/1059
+    packagingOptions {
+        exclude 'META-INF/atomicfu.kotlin_module'
+    }
 
     buildTypes {
         release {

--- a/sample/src/main/java/io/github/karino2/kotlitex/sample/MainActivity.kt
+++ b/sample/src/main/java/io/github/karino2/kotlitex/sample/MainActivity.kt
@@ -6,6 +6,7 @@ import android.text.Spannable
 import android.text.SpannableStringBuilder
 import android.util.Log
 import android.widget.TextView
+import io.github.karino2.kotlitex.MarkdownView
 import io.github.karino2.kotlitex.MathExpressionSpan
 
 class MainActivity : AppCompatActivity() {
@@ -28,8 +29,14 @@ class MainActivity : AppCompatActivity() {
         spannable.setSpan(createMathSpan("\\frac{1}{1+\\frac{1}{x^2}}", PHYSICAL_BASE_SIZE), 6, 8, Spannable.SPAN_INCLUSIVE_EXCLUSIVE)
         spannable.setSpan(createMathSpan("\\sum^N_{k=1} k", PHYSICAL_BASE_SIZE), 22, 25, Spannable.SPAN_INCLUSIVE_EXCLUSIVE)
         textView.text = spannable
+
+        findViewById<MarkdownView>(R.id.markdownView).setMarkdown("""Hello, this is math test ${"$$"}x^2${"$$"} end.
+            |${"$$"} \sum^N_{k=1} k${"$$"}
+            |Above is math line. This is a little different from inline text mode like ${"$$"} \sum^N_{k=1} k${"$$"}.
+            |${"$$"} \sqrt{5} ${"$$"}
+        """.trimMargin())
     }
 
-    fun createMathSpan(expr: String, baseSize: Float) = MathExpressionSpan(expr, baseSize, assets)
+    fun createMathSpan(expr: String, baseSize: Float) = MathExpressionSpan(expr, baseSize, assets, true)
 //    fun createMathSpan(expr: String, baseSize: Float) = MathExpressionSpan(expr, null, assets)
 }

--- a/sample/src/main/res/layout/activity_main.xml
+++ b/sample/src/main/res/layout/activity_main.xml
@@ -1,20 +1,25 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.constraint.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
-                                             xmlns:app="http://schemas.android.com/apk/res-auto"
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
                                              xmlns:tools="http://schemas.android.com/tools"
                                              android:layout_width="match_parent"
                                              android:layout_height="match_parent"
                                              tools:context="io.github.karino2.kotlitex.sample.MainActivity">
+    <LinearLayout android:layout_width="match_parent"
+                  android:layout_height="wrap_content"
+                  android:orientation="vertical">
+        <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:id="@+id/textView"
+                android:text="Hello"
+                android:textSize="24sp"/>
+        <io.github.karino2.kotlitex.MarkdownView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:id="@+id/markdownView"
+                android:text="Hello"
+                android:textSize="24sp"/>
+    </LinearLayout>
 
-    <TextView
-            android:layout_width="0dp"
-            android:layout_height="0dp"
-            android:id="@+id/textView"
-            android:layout_marginTop="8dp"
-            android:layout_marginBottom="8dp" app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintTop_toTopOf="parent" app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintBottom_toBottomOf="parent"
-            android:layout_marginStart="8dp" android:layout_marginEnd="8dp" android:text="Hello"
-            android:textSize="24sp"/>
+</ScrollView>
 
-</android.support.constraint.ConstraintLayout>


### PR DESCRIPTION
For dogfooding, I want some text view which render math expression.
I use coroutine to handle background math format.

I call math supported text view as MarkdownView because math expressoin syntax is the same as jekyll's markdown extension and I want to support jekyll markdown in the future.