### PR TITLE
Make timeout longer.

### DIFF
--- a/kotlitex/build.gradle
+++ b/kotlitex/build.gradle
@@ -14,6 +14,12 @@ android {
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
 
+    // 10 minutes seems too short. Make timeout longer.
+    adbOptions {
+        timeOutInMs 20 * 60 * 1000
+        installOptions "-d","-t"
+    }
+
     // for workaround https://github.com/Kotlin/kotlinx.coroutines/issues/1059
     packagingOptions {
         exclude 'META-INF/atomicfu.kotlin_module'


### PR DESCRIPTION
Fix #100 .
10 min seems too short. make 20 min.