### PR TITLE
Turn off connected test. As noted in #111.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,18 +5,7 @@ language: android
 
 env:
   global:
-    - ADB_INSTALL_TIMEOUT=10 # minutes
-  matrix:
     - TARGET=unit
-    - TARGET=instrumentation
-
-install:
-  # Install SDK license so Android Gradle plugin can install deps.
-  - mkdir "$ANDROID_HOME/licenses" || true
-  - echo "d56f5187479451eabf01fb78af6dfcb131a6481e" > "$ANDROID_HOME/licenses/android-sdk-license"
-  - echo "24333f8a63b6825ea9c5514f83c2829b004d1fee" >> "$ANDROID_HOME/licenses/android-sdk-license"
-  # Install the rest of tools (e.g., avdmanager)
-  - sdkmanager tools
 
 script: travis_wait ./build.sh
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,12 @@ env:
   global:
     - TARGET=unit
 
+install:
+  # Install SDK license so Android Gradle plugin can install deps.
+  - mkdir "$ANDROID_HOME/licenses" || true
+  - echo "d56f5187479451eabf01fb78af6dfcb131a6481e" > "$ANDROID_HOME/licenses/android-sdk-license"
+  - echo "24333f8a63b6825ea9c5514f83c2829b004d1fee" >> "$ANDROID_HOME/licenses/android-sdk-license"
+
 script: travis_wait ./build.sh
 
 before_cache:


### PR DESCRIPTION
Connected test is too fragile to maintain by individual development.
Also, it takes quite time.

I turn off this test until we really need this kind of test.