### PR TITLE
Fix parser

### DIFF
--- a/kotlitex/src/main/java/io/github/karino2/kotlitex/view/MarkdownView.kt
+++ b/kotlitex/src/main/java/io/github/karino2/kotlitex/view/MarkdownView.kt
@@ -20,9 +20,7 @@ class MathSpanBuilder(val handler: MathSpanHandler) {
     val builder = SpannableStringBuilder()
 
     val mathExpLinePat = "^\\$\\$([^\$]+)\\$\\$\$".toRegex()
-    //val mathExpLinePat = "^\\$\\$(.*)\\$\\$\$".toRegex()
     val mathExpPat = "\\$\\$([^$]+)\\$\\$".toRegex()
-    // val mathExpPat = "\\$\\$(.*)\$\$".toRegex()
 
     fun oneNormalLineWithoutEOL(line: String) {
         if (line.isEmpty())

--- a/kotlitex/src/main/java/io/github/karino2/kotlitex/view/MarkdownView.kt
+++ b/kotlitex/src/main/java/io/github/karino2/kotlitex/view/MarkdownView.kt
@@ -19,7 +19,8 @@ interface MathSpanHandler {
 class MathSpanBuilder(val handler: MathSpanHandler) {
     val builder = SpannableStringBuilder()
 
-    val mathExpLinePat = "^\\$\\$(.*)\\$\\$\$".toRegex()
+    val mathExpLinePat = "^\\$\\$([^\$]+)\\$\\$\$".toRegex()
+    //val mathExpLinePat = "^\\$\\$(.*)\\$\\$\$".toRegex()
     val mathExpPat = "\\$\\$([^$]+)\\$\\$".toRegex()
     // val mathExpPat = "\\$\\$(.*)\$\$".toRegex()
 

--- a/kotlitex/src/test/java/io/github/karino2/kotlitex/renderer/MathSpanBuilderTest.kt
+++ b/kotlitex/src/test/java/io/github/karino2/kotlitex/renderer/MathSpanBuilderTest.kt
@@ -67,6 +67,12 @@ class MathSpanBuilderTest {
         assertNotNull(actual)
     }
 
+    @Test
+    fun testMathExpPat_MathBegEnd_ButNotMathLine() {
+        val actual = target.mathExpLinePat.matches("\$\$x^2\$\$abc\$\$y_2\$\$")
+        assertFalse(actual)
+    }
+
     @Before
     fun setupHandler() {
         handler.reset()

--- a/kotlitex/src/test/java/io/github/karino2/kotlitex/renderer/MathSpanBuilderTest.kt
+++ b/kotlitex/src/test/java/io/github/karino2/kotlitex/renderer/MathSpanBuilderTest.kt
@@ -142,4 +142,18 @@ class MathSpanBuilderTest {
 
         handler.normals[0].assert(0, "abc def")
     }
+
+    @Test
+    fun testOneNormal_mathStart_mathEnd() {
+        target.oneLine("\$\$x^2\$\$abc\$\$y_2\$\$")
+
+        assertEquals(1, handler.normals.size)
+        assertEquals(2, handler.mathExps.size)
+
+        handler.normals[0].assert(1, "abc")
+
+        handler.mathExps[0].assert(0, "x^2")
+        handler.mathExps[1].assert(2, "y_2")
+
+    }
 }

--- a/kotlitex/src/test/java/io/github/karino2/kotlitex/renderer/MathSpanBuilderTest.kt
+++ b/kotlitex/src/test/java/io/github/karino2/kotlitex/renderer/MathSpanBuilderTest.kt
@@ -156,4 +156,16 @@ class MathSpanBuilderTest {
         handler.mathExps[1].assert(2, "y_2")
 
     }
+
+    @Test
+    fun testOneNormal_MathExpButNotMathLineEnd() {
+        target.oneLine("\$\$x^2\$\$abc")
+
+        assertEquals(1, handler.normals.size)
+        assertEquals(1, handler.mathExps.size)
+
+        handler.normals[0].assert(1, "abc")
+
+        handler.mathExps[0].assert(0, "x^2")
+    }
 }

--- a/sample/src/main/java/io/github/karino2/kotlitex/sample/MainActivity.kt
+++ b/sample/src/main/java/io/github/karino2/kotlitex/sample/MainActivity.kt
@@ -36,6 +36,7 @@ class MainActivity : AppCompatActivity() {
             |${"$$"} x_1 \ldots x_n ${"$$"}
             |${"$$"} \sqrt{5} ${"$$"}
             |Above are math lines. These are a little different from inline text mode like ${"$$"} \sum^N_{k=1} k${"$$"}.
+            |${"$$"} \sqrt{5} ${"$$"} text ${"$$"} \sum^N_{k=1} k${"$$"}
         """.trimMargin())
     }
 


### PR DESCRIPTION
fixes #123
行が$$から始まって$$で終わると、間にテキストが入っていても一つの数式として処理されていたので、中に$がある場合は一つの数式にしないようにしました。