### PR TITLE
Add check convertView and re-use

### DIFF
--- a/demoapp/src/main/java/io/github/karino2/kotlitex/demoapp/DemoActivity.kt
+++ b/demoapp/src/main/java/io/github/karino2/kotlitex/demoapp/DemoActivity.kt
@@ -100,7 +100,7 @@ class MarkListAdapter(context: Context, marks: List<String>) : ArrayAdapter<Stri
     private val inflater: LayoutInflater = LayoutInflater.from(context)
 
     override fun getView(position: Int, convertView: View?, parent: ViewGroup?): View {
-        val view = inflater.inflate(R.layout.list_markdown, parent, false)
+        val view = convertView ?: inflater.inflate(R.layout.list_markdown, parent, false)
 
         val markDown = view.findViewById<MarkdownView>(R.id.markdownView)
 


### PR DESCRIPTION
Closes #153 
MarkListAdapter always create new view, because it not use convertView.
add check convertView and if it exit,re-use.