### PR TITLE
Multiline mathexp support

### DIFF
--- a/kotlitex/build.gradle
+++ b/kotlitex/build.gradle
@@ -46,6 +46,10 @@ dependencies {
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.3.0-RC"
 
     testImplementation 'junit:junit:4.12'
+    androidTestImplementation 'androidx.test:core:1.0.0'
+    androidTestImplementation 'androidx.test:rules:1.1.0'
     androidTestImplementation 'androidx.test:runner:1.1.1'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
+    androidTestImplementation 'androidx.test.ext:junit:1.0.0'
+
 }

--- a/kotlitex/src/androidTest/java/io/github/karino2/kotlitex/RenderTreeBuilderInstrumentedTest.kt
+++ b/kotlitex/src/androidTest/java/io/github/karino2/kotlitex/RenderTreeBuilderInstrumentedTest.kt
@@ -1,8 +1,8 @@
 package io.github.karino2.kotlitex
 
-import android.support.test.InstrumentationRegistry
-import android.support.test.runner.AndroidJUnit4
 
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
 import org.junit.Test
 import org.junit.runner.RunWith
 
@@ -18,7 +18,7 @@ class RenderTreeBuilderInstrumentedTest {
     @Test
     fun useAppContext() {
         // Context of the app under test.
-        val appContext = InstrumentationRegistry.getTargetContext()
+        val appContext = InstrumentationRegistry.getInstrumentation().targetContext
         assertEquals("io.github.karino2.kotlitex.test", appContext.packageName)
     }
 

--- a/kotlitex/src/androidTest/java/io/github/karino2/kotlitex/VirtualNodeBuilderInstrumentedTest.kt
+++ b/kotlitex/src/androidTest/java/io/github/karino2/kotlitex/VirtualNodeBuilderInstrumentedTest.kt
@@ -1,7 +1,7 @@
 package io.github.karino2.kotlitex
 
-import android.support.test.InstrumentationRegistry
-import android.support.test.runner.AndroidJUnit4
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
 import io.github.karino2.kotlitex.renderer.AndroidFontLoader
 import io.github.karino2.kotlitex.renderer.VirtualNodeBuilder
 import io.github.karino2.kotlitex.renderer.node.*
@@ -71,7 +71,8 @@ class VirtualNodeBuilderInstrumentedTest {
         val parser = Parser("\\sqrt{3}")
         val renderTree = RenderTreeBuilder.buildExpression(parser.parse(), Options(Style.DISPLAY), true)
 
-        val builder = VirtualNodeBuilder(renderTree, 100.0, AndroidFontLoader(InstrumentationRegistry.getContext().assets))
+        val builder = VirtualNodeBuilder(renderTree, 100.0, AndroidFontLoader(
+            InstrumentationRegistry.getInstrumentation().targetContext.assets))
         val virtualNodeTree = builder.build();
 
         val n = findFirst(virtualNodeTree) {
@@ -90,7 +91,7 @@ class VirtualNodeBuilderInstrumentedTest {
         println("Render Tree")
         printTree(renderTree)
 
-        val builder = VirtualNodeBuilder(renderTree, 100.0, AndroidFontLoader(InstrumentationRegistry.getContext().assets))
+        val builder = VirtualNodeBuilder(renderTree, 100.0, AndroidFontLoader(InstrumentationRegistry.getInstrumentation().targetContext.assets))
         val virtualNodeTree = builder.build();
 
         println("Virtual Node Tree")

--- a/kotlitex/src/androidTest/java/io/github/karino2/kotlitex/renderer/AndroidFontLoaderTest.kt
+++ b/kotlitex/src/androidTest/java/io/github/karino2/kotlitex/renderer/AndroidFontLoaderTest.kt
@@ -1,7 +1,7 @@
 package io.github.karino2.kotlitex.renderer
 
-import android.support.test.InstrumentationRegistry
-import android.support.test.runner.AndroidJUnit4
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
 import io.github.karino2.kotlitex.renderer.node.CssFont
 import org.junit.Assert.assertEquals
 import org.junit.Test
@@ -11,7 +11,7 @@ import org.junit.runner.RunWith
 @RunWith(AndroidJUnit4::class)
 class AndroidFontLoaderTest {
     private fun createLoader(): FontLoader {
-        val ctx = InstrumentationRegistry.getTargetContext()
+        val ctx = InstrumentationRegistry.getInstrumentation().targetContext
         return AndroidFontLoader(ctx.assets)
     }
 
@@ -32,7 +32,7 @@ class AndroidFontLoaderTest {
 
     @Test
     fun fontToTypefaceMapKeyHandleNormal() {
-        val font = CssFont("KaTeX_Main", "Normal", 10.0)
+        val font = CssFont("KaTeX_Main", "Normal", "", 10.0)
         assertEquals("KaTeX_Main-Regular", AndroidFontLoader.fontToTypefaceMapKey(font))
     }
 }

--- a/kotlitex/src/main/java/io/github/karino2/kotlitex/CssClass.kt
+++ b/kotlitex/src/main/java/io/github/karino2/kotlitex/CssClass.kt
@@ -11,7 +11,7 @@ enum class CssClass {
     reset_size1, reset_size2, reset_size3, reset_size4, reset_size5, reset_size6,
     reset_size7, reset_size8, reset_size9, reset_size10, reset_size11, root,
     sizing,  size1, size2, size3, size4, size5, size6, size7, size8, size9, size10, size11,
-    small_op, sqrt, struct, stretchy, svg_align,
+    small_op, sqrt, strut, stretchy, svg_align,
     textbf, textit, textrm, textsf, texttt,
     underline, underline_line,
     EMPTY;
@@ -98,6 +98,7 @@ data class CssStyle(
     var paddingLeft: String? = null,
     var position: String? = null,
     var left: String? = null,
+    var verticalAlign: String? = null,
     var width: String? = null
 /*
     backgroundColor: string,
@@ -106,7 +107,6 @@ data class CssStyle(
     borderTopWidth: string,
     bottom: string,
 
-    verticalAlign: string,
 
  */
 )

--- a/kotlitex/src/main/java/io/github/karino2/kotlitex/CssClass.kt
+++ b/kotlitex/src/main/java/io/github/karino2/kotlitex/CssClass.kt
@@ -6,7 +6,7 @@ enum class CssClass {
     delimcenter, delimsizing, delimsizinginner, delim_size1, delim_size4,
     enclosing, frac_line, hide_tail, halfarrow_left, halfarrow_right, large_op,
     mathbb, mathbf, mathcal, mathdefault, mathit, mathscr, mbin, mclose, mfrac, minner, mop, mopen, mord, mpunct, mrel, mtight,
-    msupsub, mspace, mult, nobreak, nulldelimiter, overlay,
+    msupsub, mspace, mult, newline, nobreak, nulldelimiter, overlay,
     vlist, vlist_r, vlist_s, vlist_t, vlist_t2, pstrut, op_symbol, op_limits,
     reset_size1, reset_size2, reset_size3, reset_size4, reset_size5, reset_size6,
     reset_size7, reset_size8, reset_size9, reset_size10, reset_size11, root,
@@ -91,6 +91,7 @@ data class CssStyle(
 
     var color: String? = null,
     var marginLeft: String? = null,
+    var marginTop: String? = null,
     var marginRight: String? = null,
     var borderBottomWidth: String? = null,
     var minWidth: String? = null,
@@ -104,7 +105,6 @@ data class CssStyle(
     borderRightWidth: string,
     borderTopWidth: string,
     bottom: string,
-    marginTop: string,
 
     verticalAlign: string,
 

--- a/kotlitex/src/main/java/io/github/karino2/kotlitex/MacroExpander.kt
+++ b/kotlitex/src/main/java/io/github/karino2/kotlitex/MacroExpander.kt
@@ -1,12 +1,36 @@
 package io.github.karino2.kotlitex
 
-class MacroExpander(val input: String, var mode: Mode = Mode.MATH) {
-    val lexer = Lexer(input)
+class MacroExpander(val input: String, val settings: Settings, var mode: Mode = Mode.MATH) {
+    var lexer = Lexer(input)
 
     val stack = ArrayList<Token>()
 
-    fun beginGroup() {}
-    fun endGroup() {}
+    var expansionCount = 0
+    val macros = Namespace(Macros.builtinMacros, settings.macros)
+
+    fun ArrayList<Token>.pop() = this.removeAt(this.lastIndex)
+
+
+    /**
+     * Feed a new input string to the same MacroExpander
+     * (with existing macros etc.).
+     */
+    fun feed(input: String) {
+        lexer = Lexer(input);
+    }
+
+
+
+    /**
+     * Start a new group nesting within all namespaces.
+     */
+    fun beginGroup() { macros.beginGroup() }
+
+
+    /**
+     * End current group nesting within all namespaces.
+     */
+    fun endGroup() { macros.endGroup() }
 
     companion object {
         val implicitCommands = setOf(
@@ -31,21 +55,144 @@ class MacroExpander(val input: String, var mode: Mode = Mode.MATH) {
 
     fun pushToken(token: Token) = stack.add(token)
 
+    fun pushTokens(tokens: List<Token>) = stack.addAll(tokens)
+
+
     fun popToken(): Token {
         future()
-        return stack.removeAt(stack.size - 1)
+        return stack.pop()
+    }
+
+    /**
+     * Consume all following space tokens, without expansion.
+     */
+    fun consumeSpaces() {
+        while(true) {
+            val token = this.future();
+            if (token.text == " ") {
+                this.stack.pop();
+            } else {
+                return
+            }
+        }
+    }
+
+    /**
+     * Consume the specified number of arguments from the token stream,
+     * and return the resulting array of arguments.
+     */
+    fun consumeArgs(numArgs: Int): List<List<Token>> {
+        val args = ArrayList<ArrayList<Token>>()
+        // obtain arguments, either single token or balanced {…} group
+        repeat(numArgs) {i->
+            this.consumeSpaces()  // ignore spaces before each argument
+            val startOfArg = this.popToken()
+            when {
+                startOfArg.text == "{" -> {
+                    val arg = ArrayList<Token>()
+                    var depth = 1
+                    while (depth != 0) {
+                        val tok = this.popToken()
+                        arg.add(tok)
+                        when {
+                            tok.text == "{" -> ++depth
+                            tok.text == "}" -> --depth
+                            tok.text == "EOF" -> throw ParseError(
+                                "End of input in macro argument",
+                                startOfArg)
+                        }
+                    }
+                    arg.pop(); // remove last }
+                    arg.reverse(); // like above, to fit in with stack order
+                    args[i] = arg;
+                }
+                startOfArg.text == "EOF" -> throw ParseError(
+                    "End of input expecting macro argument", null)
+                else -> args[i] = arrayListOf(startOfArg)
+            }
+        }
+        return args
     }
 
     /*
+     * Expand the next token only once if possible.
+     *
+     * If the token is expanded, the resulting tokens will be pushed onto
+     * the stack in reverse order and will be returned as an array,
+     * also in reverse order.
+     *
+     * If not, the next token will be returned without removing it
+     * from the stack.  This case can be detected by a `Token` return value
+     * instead of an `Array` return value.
+     *
+     * In either case, the next token will be on the top of the stack,
+     * or the stack will be empty.
+     *
+     * Used to implement `expandAfterFuture` and `expandNextToken`.
+     *
+     * At the moment, macro expansion doesn't handle delimited macros,
+     * i.e. things like those defined by \def\foo#1\end{…}.
+     * See the TeX book page 202ff. for details on how those should behave.
+
+
+    Added comment for kotlitex:
        In original katex, return type is Token|Token[] and semantics is a little different.(Fully expanded or not).
        I add boolean flag to specify whether this is token[] semantics or token semantics (True means token) for kotlin.
      */
     fun expandOnce(): Pair<Boolean, List<Token>> {
         val topToken = popToken()
-        // TODO: implement expand.
+        val name = topToken.text
+        val expansion = this._getExpansion(name);
+        if (expansion == null) { // mainly checking for undefined here
+            // Fully expanded
+            this.pushToken(topToken);
+            return Pair(true, listOf(topToken))
+        }
+        expansionCount++;
+        if (this.expansionCount > this.settings.maxExpand) {
+            throw ParseError("Too many expansions: infinite loop or " +
+                    "need to increase maxExpand setting", null);
+        }
+        var tokens = expansion.tokens
+        if (expansion.numArgs > 0) {
+            val args = this.consumeArgs(expansion.numArgs);
+            // paste arguments in place of the placeholders
+            tokens = mutableListOf<Token>().apply { addAll(tokens) } // make a shallow copy
 
-        pushToken(topToken)
-        return Pair(true, listOf(topToken))
+            // index manipulation inside reverse for loop...
+            var i = tokens.size -1
+            while(i >= 0) {
+                var tok = tokens[i]
+                if (tok.text == "#") {
+                    if (i == 0) {
+                        throw ParseError(
+                                "Incomplete placeholder at end of macro body",
+                        tok)
+                    }
+                    tok = tokens[--i]; // next token on stack
+                    if (tok.text == "#") { // ## → #
+                        tokens.removeAt(i+1) // drop first #
+                    } else if ("^[1-9]$".toRegex().matches(tok.text)) {
+                        // replace the placeholder with the indicated argument
+                        val toknum = tok.text.toInt()
+
+                        //  Original JS code
+                        //  tokens.splice(i, 2, ...args[tok.text - 1]);
+                        tokens.removeAt(i)
+                        tokens.removeAt(i)
+                        tokens.addAll(i, args[toknum -1])
+                    } else {
+                        throw ParseError(
+                                "Not a valid argument number",
+                        tok)
+                    }
+                }
+                i--
+            }
+        }
+        // Concatenate expansion onto top of stack.
+        this.pushTokens(tokens);
+        return Pair(false, tokens)
     }
 
     /**
@@ -69,6 +216,47 @@ class MacroExpander(val input: String, var mode: Mode = Mode.MATH) {
         }
     }
 
+    /**
+     * Returns the expanded macro as a reversed array of tokens and a macro
+     * argument count.  Or returns `null` if no such macro.
+     */
+    fun _getExpansion(name: String): MacroExpansion? {
+        // mainly checking for undefined here
+        val definition = this.macros.get(name) ?: return null
+        val expansionDef = when(definition) {
+            is MacroFunction -> definition.func(this)
+            else->definition
+        }
+        if (expansionDef is MacroString) {
+            var numArgs = 0
+            val expansion = expansionDef.value
+
+            if (expansion.indexOf("#") != -1) {
+
+                val stripped = expansion.replace("##".toRegex(), "")
+                while (stripped.indexOf("#" + (numArgs + 1)) != -1) {
+                    ++numArgs;
+                }
+            }
+            val bodyLexer = Lexer(expansion)
+            val tokens = ArrayList<Token>()
+            var tok = bodyLexer.lex();
+            while (tok.text != "EOF") {
+                tokens.add(tok);
+                tok = bodyLexer.lex();
+            }
+            tokens.reverse() // to fit in with stack using push and pop
+            return MacroExpansion(tokens, numArgs)
+        }
+
+        //function return only MacroString or MacroExpansion.
+        return expansionDef as MacroExpansion
+    }
+
+
+    /**
+     * Switches between "text" and "math" modes.
+     */
     fun switchMode(newMode: Mode) {
         mode = newMode
     }

--- a/kotlitex/src/main/java/io/github/karino2/kotlitex/Macros.kt
+++ b/kotlitex/src/main/java/io/github/karino2/kotlitex/Macros.kt
@@ -1,0 +1,23 @@
+package io.github.karino2.kotlitex
+
+/*
+This file basically contain the code of macros.js in original katex.
+ */
+
+sealed class MacroDefinition
+
+data class MacroExpansion(val tokens: List<Token>, val numArgs: Int): MacroDefinition()
+data class MacroString(val value: String) : MacroDefinition()
+data class MacroFunction(val func: (MacroExpander)-> MacroDefinition) : MacroDefinition()
+
+object Macros {
+    val builtinMacros = mutableMapOf<String, MacroDefinition>()
+    fun defineMacro(name: String, body: MacroDefinition) {
+        builtinMacros[name] = body
+    }
+
+    fun defineAll() {
+        defineMacro("\\\\", MacroString("\\newline"))
+    }
+
+}

--- a/kotlitex/src/main/java/io/github/karino2/kotlitex/Namespace.kt
+++ b/kotlitex/src/main/java/io/github/karino2/kotlitex/Namespace.kt
@@ -1,0 +1,103 @@
+package io.github.karino2.kotlitex
+
+/**
+ * A `Namespace` refers to a space of nameable things like macros or lengths,
+ * which can be `set` either globally or local to a nested group, using an
+ * undo stack similar to how TeX implements this functionality.
+ * Performance-wise, `get` and local `set` take constant time, while global
+ * `set` takes time proportional to the depth of group nesting.
+ */
+
+/**
+ * Both arguments are optional.  The first argument is an object of
+ * built-in mappings which never change.  The second argument is an object
+ * of initial (global-level) mappings, which will constantly change
+ * according to any global/top-level `set`s done.
+ */
+class Namespace(val builtins: Map<String, MacroDefinition> = emptyMap(), globalMacros: MutableMap<String, MacroDefinition> = mutableMapOf()) {
+    val undefStack = ArrayList<MutableMap<String, MacroDefinition?>>()
+    val current = globalMacros
+
+    fun ArrayList<MutableMap<String, MacroDefinition?>>.pop()  = this.removeAt(this.lastIndex)
+
+    /**
+     * Start a new nested group, affecting future local `set`s.
+     */
+    fun beginGroup() {
+        undefStack.add(mutableMapOf());
+    }
+
+    /**
+     * End current nested group, restoring values before the group began.
+     */
+    fun endGroup() {
+        if (this.undefStack.isEmpty()) {
+            throw ParseError("Unbalanced namespace destruction: attempt " +
+                    "to pop global namespace; please report this as a bug", null)
+        }
+        val undefs = this.undefStack.pop()
+        undefs.keys.forEach {key ->
+            val content = undefs[key]
+            if(content == null) {
+                current.remove(key)
+            }else {
+                current[key] = content
+            }
+        }
+    }
+
+    /**
+     * Detect whether `name` has a definition.  Equivalent to
+     * `get(name) != null`.
+     */
+    fun has(name: String) = this.current.containsKey(name) ||
+                this.builtins.containsKey(name)
+
+    /**
+     * Get the current value of a name, or `undefined` if there is no value.
+     *
+     * Note: Do not use `if (namespace.get(...))` to detect whether a macro
+     * is defined, as the definition may be the empty string which evaluates
+     * to `false` in JavaScript.  Use `if (namespace.get(...) != null)` or
+     * `if (namespace.has(...))`.
+     */
+    fun get(name: String): MacroDefinition? {
+        return if (this.current.containsKey(name)) {
+            this.current[name]
+        } else {
+            this.builtins[name]
+        }
+    }
+
+    /**
+     * Set the current value of a name, and optionally set it globally too.
+     * Local set() sets the current value and (when appropriate) adds an undo
+     * operation to the undo stack.  Global set() may change the undo
+     * operation at every level, so takes time linear in their number.
+     */
+    fun set(name: String, value: MacroDefinition, global: Boolean = false) {
+        if (global) {
+            // Global set is equivalent to setting in all groups.  Simulate this
+            // by destroying any undos currently scheduled for this name,
+            // and adding an undo with the *new* value (in case it later gets
+            // locally reset within this environment).
+            undefStack.forEach {
+                it.remove(name)
+            }
+            if (this.undefStack.isNotEmpty()) {
+                this.undefStack.last()[name] = value
+            }
+        } else {
+            // Undo this set at end of this group (possibly to `undefined`),
+            // unless an undo is already in place, in which case that older
+            // value is the correct one.
+            if(undefStack.isNotEmpty()) {
+                val top = undefStack.last()
+                if(!top.containsKey(name)) {
+                    top[name] = this.current[name]
+                }
+            }
+        }
+        this.current[name] = value
+    }
+}

--- a/kotlitex/src/main/java/io/github/karino2/kotlitex/ParseNode.kt
+++ b/kotlitex/src/main/java/io/github/karino2/kotlitex/ParseNode.kt
@@ -57,6 +57,10 @@ data class PNodeAccent(override val mode: Mode, override val loc: SourceLocation
 data class PNodeAccentUnder(override val mode: Mode, override val loc: SourceLocation?, val label: String, val isStretchy: Boolean, val isShifty: Boolean, val base: ParseNode) : ParseNode() {
     override val type = "accentUnder"
 }
+data class PNodeCr(override val mode: Mode, override val loc: SourceLocation?, val newRow: Boolean, val newLine: Boolean, val size: Measurement?) : ParseNode() {
+    override val type = "cr"
+}
+
 data class PNodeUnderline(override val mode: Mode, override val loc: SourceLocation?, val body: ParseNode) : ParseNode() {
     override val type = "underline"
 }

--- a/kotlitex/src/main/java/io/github/karino2/kotlitex/Parser.kt
+++ b/kotlitex/src/main/java/io/github/karino2/kotlitex/Parser.kt
@@ -90,6 +90,53 @@ data class Settings(val displayMode: Boolean = false, val throwOnError: Boolean 
                         */
         }
     }
+
+    /**
+     * Check whether to apply strict (LaTeX-adhering) behavior for unusual
+     * input (like `\\`).  Unlike `nonstrict`, will not throw an error;
+     * instead, "error" translates to a return value of `true`, while "ignore"
+     * translates to a return value of `false`.  May still print a warning:
+     * "warn" prints a warning and returns `false`.
+     * This is for the second category of `errorCode`s listed in the README.
+     */
+    fun useStrictBehavior(errorCode: String, errorMsg: String, token: Any? /* Token | AnyParseNode*/) : Boolean {
+        // TODO:
+        /*
+        val strict = this.strict;
+        if (typeof strict === "function") {
+            // Allow return value of strict function to be boolean or string
+            // (or null/undefined, meaning no further processing).
+            // But catch any exceptions thrown by function, treating them
+            // like "error".
+            try {
+                strict = strict(errorCode, errorMsg, token);
+            } catch (error) {
+                strict = "error";
+            }
+        }
+
+         */
+        return if (strict == null || strict == "ignore") {
+            false
+        } else if (strict == true || strict == "error") {
+            true
+        } else if (strict == "warn") {
+            /*
+            typeof console !== "undefined" && console.warn(
+                "LaTeX-incompatible input and strict mode is set to 'warn': " +
+                        `${errorMsg} [${errorCode}]`);
+                */
+            false
+        } else {  // won't happen in type-safe code
+            /*
+            typeof console !== "undefined" && console.warn(
+                "LaTeX-incompatible input and strict mode is set to " +
+                        `unrecognized '${strict}': ${errorMsg} [${errorCode}]`);
+
+             */
+            false
+        }
+    }
 }
 
 data class AccentRelation(val text: String, val math: String) {
@@ -111,6 +158,7 @@ class Parser(val input: String, val settings: Settings = Settings()) {
             FunctionUnderline.defineAll()
             FunctionSymbolsSpacing.defineAll()
             FunctionMClass.defineAll()
+            FunctionCr.defineAll()
         }
     }
 

--- a/kotlitex/src/main/java/io/github/karino2/kotlitex/Parser.kt
+++ b/kotlitex/src/main/java/io/github/karino2/kotlitex/Parser.kt
@@ -51,7 +51,7 @@ data class CharInfo(val font: Font, val group: Group, val replace: String?)
 
 data class Settings(val displayMode: Boolean = false, val throwOnError: Boolean = true,
                     val errorColor: String = "#cc0000",
-                    val macros: Map<String, Any?> /*MacroMap*/ =  mapOf(),
+                    val macros: MutableMap<String, MacroDefinition> /*MacroMap*/ =  mutableMapOf(),
                     val colorIsTextColor: Boolean = false,
                     val strict : Any? /* strict: boolean | "ignore" | "warn" | "error" | StrictFunction */ = "warn",
                     val maxSize: Int = Int.MAX_VALUE,
@@ -159,12 +159,14 @@ class Parser(val input: String, val settings: Settings = Settings()) {
             FunctionSymbolsSpacing.defineAll()
             FunctionMClass.defineAll()
             FunctionCr.defineAll()
+
+            Macros.defineAll()
         }
     }
 
     var mode = Mode.MATH
     var _nextToken: Token? = null
-    val gullet = MacroExpander(input, mode)
+    val gullet = MacroExpander(input, settings, mode)
 
     fun consume() {
         _nextToken = gullet.expandNextToken()

--- a/kotlitex/src/main/java/io/github/karino2/kotlitex/functions/FunctionCr.kt
+++ b/kotlitex/src/main/java/io/github/karino2/kotlitex/functions/FunctionCr.kt
@@ -1,0 +1,76 @@
+package io.github.karino2.kotlitex.functions
+
+import io.github.karino2.kotlitex.*
+import java.lang.IllegalArgumentException
+
+object FunctionCr {
+    fun defineAll() {
+        LatexFunctions.defineFunction(
+            FunctionSpec(
+                "cr",
+                0,
+                numOptionalArgs = 1,
+                argTypes = listOf(ArgSize),
+                allowedInText = true
+            ),
+            listOf("\\cr", "\\newline"),
+            { context: FunctionContext, _ /* args */: List<ParseNode>, optArgs: List<ParseNode?> ->
+                val parser = context.parser
+                val funcName = context.funcName
+
+
+                val size = optArgs[0]
+                val newRow = (funcName == "\\cr")
+                val newLine =
+                    if (newRow)
+                        false
+                    else {
+                        !(parser.settings.displayMode &&
+                                parser.settings.useStrictBehavior(
+                                    "newLineInDisplayMode", "In LaTeX, \\\\ or \\newline " +
+                                            "does nothing in display mode", null
+                                ))
+                    }
+
+                //  size = size && assertNodeType(size, "size").value,
+                val sizeArg = size?.let {
+                    if (it is PNodeSize) {
+                        it.value
+                    } else
+                        null
+                }
+
+                PNodeCr(
+                    parser.mode,
+                    null,
+                    newRow,
+                    newLine,
+                    sizeArg
+                )
+
+            },
+            // The following builders are called only at the top level,
+            // not within tabular/array environments.
+            { group: ParseNode, options: Options ->
+                if (group !is PNodeCr) {
+                    throw IllegalArgumentException("unexpected type in cr RNodeBuilder.")
+                }
+                if (group.newRow) {
+                    throw ParseError(
+                        "\\cr valid only within a tabular/array environment", null
+                    )
+                }
+                val span =
+                    RenderTreeBuilder.makeSpan(mutableSetOf(CssClass.mspace), options = options)
+                if (group.newLine) {
+                    span.klasses.add(CssClass.newline)
+                    group.size?.let {
+                        val top = RenderTreeBuilder.calculateSize(group.size, options)
+                        span.style.marginTop = "${top}em";
+                    }
+                }
+                span
+            }
+        )
+    }
+}

--- a/kotlitex/src/main/java/io/github/karino2/kotlitex/renderer/node/ClassStateMapping.kt
+++ b/kotlitex/src/main/java/io/github/karino2/kotlitex/renderer/node/ClassStateMapping.kt
@@ -4,6 +4,7 @@ import io.github.karino2.kotlitex.CssClass
 import io.github.karino2.kotlitex.RNodeSpan
 import io.github.karino2.kotlitex.RenderNode
 import io.github.karino2.kotlitex.renderer.RenderingState
+import kotlin.math.max
 
 object ClassStateMapping {
     fun createState(klass: CssClass, state: RenderingState, node: RenderNode): RenderingState {
@@ -39,6 +40,30 @@ object ClassStateMapping {
                 tableRow.margin.left = state.marginLeft
                 tableRow.margin.right = state.marginRight
                 state.copy(pstrut = height)
+            }
+            CssClass.base -> {
+                val height = node.height * state.fontSize()
+                val strut = HPaddingNode(state.klasses)
+                val depth = node.depth * state.fontSize()
+                strut.setPosition(state.nextX(), state.y - height)
+                strut.bounds.height = height+depth
+                val lastRow = state.vlist.last()!!
+                // What's depth?
+                // lastRow.depth = depth
+                lastRow.addBaseStrut(strut)
+                state
+            }
+            CssClass.newline -> {
+                val tableRow= VerticalListRow(state.klasses)
+                val strutBounds = state.vlist.last()!!.strutBounds!!
+                val marginTop = node.style.marginTop
+                val topPadding = marginTop?.let { state.parseEm(marginTop) }  ?: 0.0
+                state.vlist.addRow(tableRow)
+                tableRow.setPosition(state.nextX(), state.y)
+                val lineHeight = state.fontSize() * 1.2
+                val strutHeight = strutBounds.height
+                val yOffset = max(lineHeight, strutHeight)
+                state.copy(pstrut = yOffset + topPadding)
             }
             CssClass.underline_line -> {
                 withHorizLine(state, node)

--- a/kotlitex/src/main/java/io/github/karino2/kotlitex/renderer/node/ClassStateMapping.kt
+++ b/kotlitex/src/main/java/io/github/karino2/kotlitex/renderer/node/ClassStateMapping.kt
@@ -46,7 +46,7 @@ object ClassStateMapping {
                 val strut = HPaddingNode(state.klasses)
                 val depth = node.depth * state.fontSize()
                 strut.setPosition(state.nextX(), state.y - height)
-                strut.bounds.height = height+depth
+                strut.bounds.height = height + depth
                 val lastRow = state.vlist.last()!!
                 // What's depth?
                 // lastRow.depth = depth
@@ -54,10 +54,10 @@ object ClassStateMapping {
                 state
             }
             CssClass.newline -> {
-                val tableRow= VerticalListRow(state.klasses)
+                val tableRow = VerticalListRow(state.klasses)
                 val strutBounds = state.vlist.last()!!.strutBounds!!
                 val marginTop = node.style.marginTop
-                val topPadding = marginTop?.let { state.parseEm(marginTop) }  ?: 0.0
+                val topPadding = marginTop?.let { state.parseEm(marginTop) } ?: 0.0
                 state.vlist.addRow(tableRow)
                 tableRow.setPosition(state.nextX(), state.y)
                 val lineHeight = state.fontSize() * 1.2

--- a/kotlitex/src/main/java/io/github/karino2/kotlitex/view/MarkdownView.kt
+++ b/kotlitex/src/main/java/io/github/karino2/kotlitex/view/MarkdownView.kt
@@ -10,8 +10,8 @@ import kotlinx.coroutines.* // ktlint-disable no-wildcard-imports
 
 interface MathSpanHandler {
     fun appendNormal(text: String)
-    fun appendMathExp(exp: String)
-    fun appendMathLineExp(text: String)
+    fun appendInlineMathExp(exp: String)
+    fun appendDisplayMathExp(text: String)
     fun appendEndOfLine()
 }
 
@@ -37,7 +37,7 @@ class MathSpanBuilder(val handler: MathSpanHandler) {
         while (res != null) {
             if (lastMatchPos != res.range.start)
                 handler.appendNormal(line.substring(lastMatchPos, res.range.start))
-            handler.appendMathExp(res.groupValues[1])
+            handler.appendInlineMathExp(res.groupValues[1])
             lastMatchPos = res.range.last + 1
             res = res.next()
         }
@@ -52,7 +52,7 @@ class MathSpanBuilder(val handler: MathSpanHandler) {
             inMultiLineMath = false
             val exp = multiLineMathBuffer.toString()
             if (exp.isNotEmpty()) {
-                handler.appendMathLineExp(exp)
+                handler.appendDisplayMathExp(exp)
             }
             multiLineMathBuffer.clear()
             return
@@ -71,7 +71,7 @@ class MathSpanBuilder(val handler: MathSpanHandler) {
             return
         }
         mathExpLinePat.matchEntire(line)?.let {
-            handler.appendMathLineExp(it.groupValues[1])
+            handler.appendDisplayMathExp(it.groupValues[1])
             return
         }
 
@@ -100,7 +100,7 @@ class SpannableMathSpanHandler(val assetManager: AssetManager, val baseSize: Flo
         spannable.append(text)
     }
 
-    override fun appendMathExp(exp: String) {
+    override fun appendInlineMathExp(exp: String) {
         appendMathSpan(exp, false)
     }
 
@@ -114,7 +114,7 @@ class SpannableMathSpanHandler(val assetManager: AssetManager, val baseSize: Flo
         spannable.setSpan(span, begin, spannable.length, Spannable.SPAN_INCLUSIVE_EXCLUSIVE)
     }
 
-    override fun appendMathLineExp(text: String) {
+    override fun appendDisplayMathExp(text: String) {
         appendMathSpan(text, true)
         spannable.append("\n")
     }

--- a/kotlitex/src/main/java/io/github/karino2/kotlitex/view/MarkdownView.kt
+++ b/kotlitex/src/main/java/io/github/karino2/kotlitex/view/MarkdownView.kt
@@ -51,7 +51,7 @@ class MathSpanBuilder(val handler: MathSpanHandler) {
         multiLineMathBeginEndPat.matchEntire(line)?.let {
             inMultiLineMath = false
             val exp = multiLineMathBuffer.toString()
-            if(exp.isNotEmpty()) {
+            if (exp.isNotEmpty()) {
                 handler.appendMathLineExp(exp)
             }
             multiLineMathBuffer.clear()
@@ -59,11 +59,10 @@ class MathSpanBuilder(val handler: MathSpanHandler) {
         }
         multiLineMathBuffer.append(line)
         multiLineMathBuffer.append(" ")
-
     }
 
     fun oneLine(line: String) {
-        if(inMultiLineMath) {
+        if (inMultiLineMath) {
             oneLineInMultilineMath(line)
             return
         }

--- a/kotlitex/src/main/java/io/github/karino2/kotlitex/view/MathExpressionSpan.kt
+++ b/kotlitex/src/main/java/io/github/karino2/kotlitex/view/MathExpressionSpan.kt
@@ -22,7 +22,7 @@ private class MathExpressionDrawable(expr: String, baseSize: Float, val fontLoad
         )
         val parser = Parser(expr)
         val parsed = parser.parse()
-        val nodes = RenderTreeBuilder.buildExpression(parsed, options, true)
+        val nodes = RenderTreeBuilder.buildHTML(parsed, options)
         val builder = VirtualNodeBuilder(nodes, baseSize.toDouble(), fontLoader)
         rootNode = builder.build()
     }

--- a/kotlitex/src/main/java/io/github/karino2/kotlitex/view/MathExpressionSpan.kt
+++ b/kotlitex/src/main/java/io/github/karino2/kotlitex/view/MathExpressionSpan.kt
@@ -17,9 +17,9 @@ import kotlin.math.roundToInt
 private class MathExpressionDrawable(expr: String, baseSize: Float, val fontLoader: FontLoader, val isMathMode: Boolean, val drawBounds: Boolean = false) {
     var rootNode: VerticalList
 
-    val firstVListRowBound : Bounds?
+    val firstVListRowBound: Bounds?
     get() {
-        if(rootNode.nodes.isEmpty())
+        if (rootNode.nodes.isEmpty())
             return null
 
         val b = Bounds(rootNode.bounds.x, rootNode.bounds.y)
@@ -73,7 +73,7 @@ private class MathExpressionDrawable(expr: String, baseSize: Float, val fontLoad
         val x = translateX(bounds.x)
         val y = translateY(bounds.y)
 
-        drawBoundsRect(canvas, RectF(x, y- bounds.height.toFloat(), x + bounds.width.toFloat(), y), Color.RED)
+        drawBoundsRect(canvas, RectF(x, y - bounds.height.toFloat(), x + bounds.width.toFloat(), y), Color.RED)
     }
 
     private fun drawWholeBound(canvas: Canvas, bounds: Bounds) {
@@ -85,7 +85,7 @@ private class MathExpressionDrawable(expr: String, baseSize: Float, val fontLoad
 
         val firstBound = firstVListRowBound ?: return
 
-        val ascent = (0.5+ firstBound.height*4/5).toInt()
+        val ascent = (0.5 + firstBound.height * 4 / 5).toInt()
 
         /*
         work around for \sum^N_i case. (#161)
@@ -97,10 +97,8 @@ private class MathExpressionDrawable(expr: String, baseSize: Float, val fontLoad
         val y = -ascent
         // val padding = (ascent/9).toInt()
         val padding = 0
-        drawBoundsRect(canvas, RectF(x, (y-padding).toFloat(), x + bounds.width.toFloat()+padding, y+padding*2+(bounds.height+deltaDescent).toFloat()), Color.BLUE)
+        drawBoundsRect(canvas, RectF(x, (y - padding).toFloat(), x + bounds.width.toFloat() + padding, y + padding*2 + (bounds.height + deltaDescent).toFloat()), Color.BLUE)
     }
-
-
 
     private fun drawRenderNodes(canvas: Canvas, parent: VirtualCanvasNode) {
         when (parent) {
@@ -112,8 +110,8 @@ private class MathExpressionDrawable(expr: String, baseSize: Float, val fontLoad
             is TextNode -> {
                 textPaint.typeface = fontLoader.toTypeface(parent.font)
                 textPaint.textSize = parent.font.size.toFloat()
-                val x = translateX(parent.bounds.x )
-                val y = translateY(parent.bounds.y )
+                val x = translateX(parent.bounds.x)
+                val y = translateY(parent.bounds.y)
                 canvas.drawText(parent.text, x, y, textPaint)
                 drawBounds(canvas, parent.bounds)
             }
@@ -247,27 +245,25 @@ class MathExpressionSpan(val expr: String, val baseHeight: Float, val assetManag
 
         val bottom = (rect.bottom + 0.5).roundToInt()
 
-        val ascent = (0.5+firstBound.height*4/5).toInt()
-
+        val ascent = (0.5 + firstBound.height * 4 / 5).toInt()
 
         /*
         work around for \sum^N_i case. (#161)
         In this case, firstBound.y becomes negative and normal acent calculation make ascent too upper.
         I don't know how to handle this, so extend descend to try to avoid overlap for this case.
          */
-        val deltaDescent = (0.5-firstBound.y).roundToInt()
+        val deltaDescent = (0.5 - firstBound.y).roundToInt()
 
+        val padding = ascent / 9
+        val descent = bottom - ascent + deltaDescent
 
-        val padding = ascent/9
-        val descent = bottom - ascent+deltaDescent
-
-        fm.ascent = -ascent-padding
-        fm.descent = descent+padding
+        fm.ascent = -ascent - padding
+        fm.descent = descent + padding
 
         fm.bottom = fm.descent
         fm.top = -ascent
 
-        return (rect.right+0.5+padding).roundToInt()
+        return (rect.right + 0.5 + padding).roundToInt()
     }
 
     fun ensureDrawable() {

--- a/kotlitex/src/test/java/io/github/karino2/kotlitex/RenderTreeBuilderTest.kt
+++ b/kotlitex/src/test/java/io/github/karino2/kotlitex/RenderTreeBuilderTest.kt
@@ -304,13 +304,11 @@ class RenderTreeBuilderTest {
         assertEquals(3, actual.size)
     }
 
-    /*
     @Test
     fun buildExpression_multiline() {
         val actual = buildDisplayExpression("x \\\\ y")
         assertEquals(3, actual.size)
     }
-    */
 
     private fun buildDisplayExpression(expression: String): List<RenderNode> {
         val input = parse(expression, Settings(displayMode = true))

--- a/kotlitex/src/test/java/io/github/karino2/kotlitex/RenderTreeBuilderTest.kt
+++ b/kotlitex/src/test/java/io/github/karino2/kotlitex/RenderTreeBuilderTest.kt
@@ -297,6 +297,28 @@ class RenderTreeBuilderTest {
         assertEquals(1, actual.size)
     }
 
+
+    @Test
+    fun buildExpression_newline() {
+        val actual = buildDisplayExpression("x \\newline y")
+        assertEquals(3, actual.size)
+    }
+
+    /*
+    @Test
+    fun buildExpression_multiline() {
+        val actual = buildDisplayExpression("x \\\\ y")
+        assertEquals(3, actual.size)
+    }
+    */
+
+    private fun buildDisplayExpression(expression: String): List<RenderNode> {
+        val input = parse(expression, Settings(displayMode = true))
+        val actual = RenderTreeBuilder.buildExpression(input, options, true)
+        return actual
+    }
+
+
     private fun buildExpression(expression: String): List<RenderNode> {
         val input = parse(expression)
         val actual = RenderTreeBuilder.buildExpression(input, options, true)

--- a/kotlitex/src/test/java/io/github/karino2/kotlitex/renderer/MathSpanBuilderTest.kt
+++ b/kotlitex/src/test/java/io/github/karino2/kotlitex/renderer/MathSpanBuilderTest.kt
@@ -174,4 +174,47 @@ class MathSpanBuilderTest {
 
         handler.mathExps[0].assert(0, "x^2")
     }
+
+
+    @Test
+    fun testMultiLineMathBegin() {
+        assertFalse(target.inMultiLineMath)
+        target.oneLine("\$\$")
+        assertTrue(target.inMultiLineMath)
+        assertEquals(0, handler.normals.size)
+        assertEquals(0, handler.mathExps.size)
+    }
+
+    @Test
+    fun testMultiLineMathEndWithEmpty() {
+        target.oneLine("\$\$")
+        target.oneLine("\$\$")
+        assertFalse(target.inMultiLineMath)
+        assertEquals(0, handler.normals.size)
+        assertEquals(0, handler.mathLine.size)
+    }
+
+    @Test
+    fun testMultiLineMath() {
+        target.oneLine("\$\$")
+        target.oneLine("x+y \\\\")
+        target.oneLine("z+w")
+        target.oneLine("\$\$")
+        assertFalse(target.inMultiLineMath)
+        assertEquals(1, handler.mathLine.size)
+        assertEquals(0, handler.normals.size)
+    }
+
+    @Test
+    fun testMultiLineMathAfter() {
+        target.oneLine("\$\$")
+        target.oneLine("x+y \\\\")
+        target.oneLine("z+w")
+        target.oneLine("\$\$")
+        assertFalse(target.inMultiLineMath)
+        target.oneLine("abc")
+        assertEquals(1, handler.mathLine.size)
+        assertEquals(1, handler.normals.size)
+    }
+
 }

--- a/kotlitex/src/test/java/io/github/karino2/kotlitex/renderer/MathSpanBuilderTest.kt
+++ b/kotlitex/src/test/java/io/github/karino2/kotlitex/renderer/MathSpanBuilderTest.kt
@@ -10,15 +10,15 @@ class MathSpanBuilderTest {
     class HandlerForTest : MathSpanHandler {
         var counter = 0
         val normals = ArrayList<Pair<Int, String>>()
-        val mathLine = ArrayList<Pair<Int, String>>()
-        val mathExps = ArrayList<Pair<Int, String>>()
+        val displayMathExps = ArrayList<Pair<Int, String>>()
+        val inlineMathExps = ArrayList<Pair<Int, String>>()
         val eols = ArrayList<Int>()
 
         fun reset() {
             counter = 0
             normals.clear()
-            mathLine.clear()
-            mathExps.clear()
+            displayMathExps.clear()
+            inlineMathExps.clear()
             eols.clear()
         }
 
@@ -26,12 +26,12 @@ class MathSpanBuilderTest {
             normals.add(Pair(counter++, text))
         }
 
-        override fun appendMathLineExp(text: String) {
-            mathLine.add(Pair(counter++, text))
+        override fun appendDisplayMathExp(text: String) {
+            displayMathExps.add(Pair(counter++, text))
         }
 
-        override fun appendMathExp(exp: String) {
-            mathExps.add(Pair(counter++, exp))
+        override fun appendInlineMathExp(exp: String) {
+            inlineMathExps.add(Pair(counter++, exp))
         }
 
         override fun appendEndOfLine() {
@@ -87,15 +87,15 @@ class MathSpanBuilderTest {
     @Test
     fun testMathLine() {
         target.oneLine("\$\$x^2\$\$")
-        handler.mathLine[0].assert(0, "x^2")
+        handler.displayMathExps[0].assert(0, "x^2")
     }
 
     @Test
     fun testOneLine_EmptyLine() {
         target.oneLine("")
 
-        assertTrue(handler.mathLine.isEmpty())
-        assertTrue(handler.mathExps.isEmpty())
+        assertTrue(handler.displayMathExps.isEmpty())
+        assertTrue(handler.inlineMathExps.isEmpty())
         assertTrue(handler.normals.isEmpty())
         assertEquals(1, handler.eols.size)
         assertEquals(0, handler.eols[0])
@@ -106,13 +106,13 @@ class MathSpanBuilderTest {
     fun testOneLine_Mixed() {
         target.oneLine("abc\$\$x^2\$\$")
 
-        assertTrue(handler.mathLine.isEmpty())
-        assertEquals(1, handler.mathExps.size)
+        assertTrue(handler.displayMathExps.isEmpty())
+        assertEquals(1, handler.inlineMathExps.size)
         assertEquals(1, handler.normals.size)
         assertEquals(1, handler.eols.size)
 
         handler.normals[0].assert(0, "abc")
-        handler.mathExps[0].assert(1, "x^2")
+        handler.inlineMathExps[0].assert(1, "x^2")
         assertEquals(2, handler.eols[0])
     }
 
@@ -120,7 +120,7 @@ class MathSpanBuilderTest {
     fun testOneNormal_normalEnd() {
         target.oneLine("\$\$x^2\$\$def")
         handler.normals[0].assert(1, "def")
-        handler.mathExps[0].assert(0, "x^2")
+        handler.inlineMathExps[0].assert(0, "x^2")
     }
 
     @Test
@@ -128,14 +128,14 @@ class MathSpanBuilderTest {
         target.oneLine("abc\$\$x^2\$\$def\$\$y_2\$\$ghi")
 
         assertEquals(3, handler.normals.size)
-        assertEquals(2, handler.mathExps.size)
+        assertEquals(2, handler.inlineMathExps.size)
 
         handler.normals[0].assert(0, "abc")
         handler.normals[1].assert(2, "def")
         handler.normals[2].assert(4, "ghi")
 
-        handler.mathExps[0].assert(1, "x^2")
-        handler.mathExps[1].assert(3, "y_2")
+        handler.inlineMathExps[0].assert(1, "x^2")
+        handler.inlineMathExps[1].assert(3, "y_2")
 
     }
 
@@ -144,7 +144,7 @@ class MathSpanBuilderTest {
         target.oneLine("abc def")
 
         assertEquals(1, handler.normals.size)
-        assertTrue(handler.mathExps.isEmpty())
+        assertTrue(handler.inlineMathExps.isEmpty())
 
         handler.normals[0].assert(0, "abc def")
     }
@@ -154,12 +154,12 @@ class MathSpanBuilderTest {
         target.oneLine("\$\$x^2\$\$abc\$\$y_2\$\$")
 
         assertEquals(1, handler.normals.size)
-        assertEquals(2, handler.mathExps.size)
+        assertEquals(2, handler.inlineMathExps.size)
 
         handler.normals[0].assert(1, "abc")
 
-        handler.mathExps[0].assert(0, "x^2")
-        handler.mathExps[1].assert(2, "y_2")
+        handler.inlineMathExps[0].assert(0, "x^2")
+        handler.inlineMathExps[1].assert(2, "y_2")
 
     }
 
@@ -168,11 +168,11 @@ class MathSpanBuilderTest {
         target.oneLine("\$\$x^2\$\$abc")
 
         assertEquals(1, handler.normals.size)
-        assertEquals(1, handler.mathExps.size)
+        assertEquals(1, handler.inlineMathExps.size)
 
         handler.normals[0].assert(1, "abc")
 
-        handler.mathExps[0].assert(0, "x^2")
+        handler.inlineMathExps[0].assert(0, "x^2")
     }
 
 
@@ -182,7 +182,7 @@ class MathSpanBuilderTest {
         target.oneLine("\$\$")
         assertTrue(target.inMultiLineMath)
         assertEquals(0, handler.normals.size)
-        assertEquals(0, handler.mathExps.size)
+        assertEquals(0, handler.inlineMathExps.size)
     }
 
     @Test
@@ -191,7 +191,7 @@ class MathSpanBuilderTest {
         target.oneLine("\$\$")
         assertFalse(target.inMultiLineMath)
         assertEquals(0, handler.normals.size)
-        assertEquals(0, handler.mathLine.size)
+        assertEquals(0, handler.displayMathExps.size)
     }
 
     @Test
@@ -201,7 +201,7 @@ class MathSpanBuilderTest {
         target.oneLine("z+w")
         target.oneLine("\$\$")
         assertFalse(target.inMultiLineMath)
-        assertEquals(1, handler.mathLine.size)
+        assertEquals(1, handler.displayMathExps.size)
         assertEquals(0, handler.normals.size)
     }
 
@@ -213,7 +213,7 @@ class MathSpanBuilderTest {
         target.oneLine("\$\$")
         assertFalse(target.inMultiLineMath)
         target.oneLine("abc")
-        assertEquals(1, handler.mathLine.size)
+        assertEquals(1, handler.displayMathExps.size)
         assertEquals(1, handler.normals.size)
     }
 

--- a/sample/src/main/java/io/github/karino2/kotlitex/sample/MainActivity.kt
+++ b/sample/src/main/java/io/github/karino2/kotlitex/sample/MainActivity.kt
@@ -20,12 +20,10 @@ class MainActivity : AppCompatActivity() {
 
         val textView = findViewById<TextView>(R.id.textView)
         val spannable = SpannableStringBuilder("01234 This is direct math span test.")
-        // spannable.setSpan(createMathSpan("x^2", PHYSICAL_BASE_SIZE), 0, 2, Spannable.SPAN_INCLUSIVE_EXCLUSIVE)
-        spannable.setSpan(createMathSpan("x \\\\ y", PHYSICAL_BASE_SIZE), 0, 2, Spannable.SPAN_INCLUSIVE_EXCLUSIVE)
+        spannable.setSpan(createMathSpan("x^2", PHYSICAL_BASE_SIZE), 0, 2, Spannable.SPAN_INCLUSIVE_EXCLUSIVE)
         textView.text = spannable
 
         MarkdownView.CACHE_ENABLED = false
-        /*
         findViewById<MarkdownView>(R.id.markdownView).setMarkdown("""yyyy gg. No math line with large descent(y).
             |${"$$"} \sum^N_{k=1} k${"$$"}
             |Inline math ${"$$"}x^2${"$$"} support.
@@ -44,8 +42,6 @@ class MainActivity : AppCompatActivity() {
             |Above are math lines. These are a little different from inline text mode like ${"$$"} \sum^N_{k=1} k${"$$"}.
             |${"$$"} \sqrt{5} ${"$$"} text ${"$$"} \sum^N_{k=1} k${"$$"}
         """.trimMargin())
-
-         */
     }
 
     fun createMathSpan(expr: String, baseSize: Float) =

--- a/sample/src/main/java/io/github/karino2/kotlitex/sample/MainActivity.kt
+++ b/sample/src/main/java/io/github/karino2/kotlitex/sample/MainActivity.kt
@@ -29,7 +29,11 @@ class MainActivity : AppCompatActivity() {
             |Inline math ${"$$"}x^2${"$$"} support.
             |${"$$"} \mathbb{R} ${"$$"}, ${"$$"} \mathscr{F} ${"$$"}, ${"$$"} \bar{A} ${"$$"},
             |${"$$"} x\ y T^I g_g${"$$"}
-            |${"$$"} 3x + 4y \\ 2x + 3y ${"$$"}
+            |Multiline test
+            |${"$$"}
+            |3x + 4y \\
+            |2x + 3y
+            |${"$$"}
             |${"$$"} \mathcal{X} = \{1, 2, 3\} ${"$$"}
             |${"$$"}P_x(a) = \frac{N(a|x)}{n} ${"$$"}
             |${"$$"}\underline{p_i} ${"$$"}

--- a/sample/src/main/java/io/github/karino2/kotlitex/sample/MainActivity.kt
+++ b/sample/src/main/java/io/github/karino2/kotlitex/sample/MainActivity.kt
@@ -20,10 +20,12 @@ class MainActivity : AppCompatActivity() {
 
         val textView = findViewById<TextView>(R.id.textView)
         val spannable = SpannableStringBuilder("01234 This is direct math span test.")
-        spannable.setSpan(createMathSpan("x^2", PHYSICAL_BASE_SIZE), 0, 2, Spannable.SPAN_INCLUSIVE_EXCLUSIVE)
+        // spannable.setSpan(createMathSpan("x^2", PHYSICAL_BASE_SIZE), 0, 2, Spannable.SPAN_INCLUSIVE_EXCLUSIVE)
+        spannable.setSpan(createMathSpan("x \\\\ y", PHYSICAL_BASE_SIZE), 0, 2, Spannable.SPAN_INCLUSIVE_EXCLUSIVE)
         textView.text = spannable
 
         MarkdownView.CACHE_ENABLED = false
+        /*
         findViewById<MarkdownView>(R.id.markdownView).setMarkdown("""yyyy gg. No math line with large descent(y).
             |${"$$"} \sum^N_{k=1} k${"$$"}
             |Inline math ${"$$"}x^2${"$$"} support.
@@ -42,6 +44,8 @@ class MainActivity : AppCompatActivity() {
             |Above are math lines. These are a little different from inline text mode like ${"$$"} \sum^N_{k=1} k${"$$"}.
             |${"$$"} \sqrt{5} ${"$$"} text ${"$$"} \sum^N_{k=1} k${"$$"}
         """.trimMargin())
+
+         */
     }
 
     fun createMathSpan(expr: String, baseSize: Float) =

--- a/sample/src/main/java/io/github/karino2/kotlitex/sample/MainActivity.kt
+++ b/sample/src/main/java/io/github/karino2/kotlitex/sample/MainActivity.kt
@@ -47,7 +47,7 @@ class MainActivity : AppCompatActivity() {
             |Above are math lines. These are a little different from inline text mode like ${"$$"} \sum^N_{k=1} k${"$$"}.
             |${"$$"} \sqrt{5} ${"$$"} text ${"$$"} \sum^N_{k=1} k${"$$"}
         """.trimMargin())
-   }
+    }
 
     fun createMathSpan(expr: String, baseSize: Float, isMathMode: Boolean = true) =
         MathExpressionSpan(expr, baseSize, assets, isMathMode)

--- a/sample/src/main/java/io/github/karino2/kotlitex/sample/MainActivity.kt
+++ b/sample/src/main/java/io/github/karino2/kotlitex/sample/MainActivity.kt
@@ -20,7 +20,7 @@ class MainActivity : AppCompatActivity() {
 
         val textView = findViewById<TextView>(R.id.textView)
         val spannable = SpannableStringBuilder("01234 This is direct math span test.")
-        spannable.setSpan(createMathSpan("x^2", PHYSICAL_BASE_SIZE), 0, 2, Spannable.SPAN_INCLUSIVE_EXCLUSIVE)
+        spannable.setSpan(createMathSpan("T^I g_g", PHYSICAL_BASE_SIZE, false), 0, 2, Spannable.SPAN_INCLUSIVE_EXCLUSIVE)
         textView.text = spannable
 
         MarkdownView.CACHE_ENABLED = false
@@ -28,7 +28,8 @@ class MainActivity : AppCompatActivity() {
             |${"$$"} \sum^N_{k=1} k${"$$"}
             |Inline math ${"$$"}x^2${"$$"} support.
             |${"$$"} \mathbb{R} ${"$$"}, ${"$$"} \mathscr{F} ${"$$"}, ${"$$"} \bar{A} ${"$$"},
-            |${"$$"} x\ y${"$$"}
+            |${"$$"} x\ y T^I g_g${"$$"}
+            |${"$$"} 3x + 4y \\ 2x + 3y ${"$$"}
             |${"$$"} \mathcal{X} = \{1, 2, 3\} ${"$$"}
             |${"$$"}P_x(a) = \frac{N(a|x)}{n} ${"$$"}
             |${"$$"}\underline{p_i} ${"$$"}
@@ -42,8 +43,8 @@ class MainActivity : AppCompatActivity() {
             |Above are math lines. These are a little different from inline text mode like ${"$$"} \sum^N_{k=1} k${"$$"}.
             |${"$$"} \sqrt{5} ${"$$"} text ${"$$"} \sum^N_{k=1} k${"$$"}
         """.trimMargin())
-    }
+   }
 
-    fun createMathSpan(expr: String, baseSize: Float) =
-        MathExpressionSpan(expr, baseSize, assets, true)
+    fun createMathSpan(expr: String, baseSize: Float, isMathMode: Boolean = true) =
+        MathExpressionSpan(expr, baseSize, assets, isMathMode)
 }


### PR DESCRIPTION
Support #135.

Port buildHTML function and use it. Support newline. Support macro.
Change ascent calculation based on first vlist row to handle multiple math lines correctly.
This also fix #134.